### PR TITLE
feat: add algorithm blockquote type

### DIFF
--- a/src/components/Notie.tsx
+++ b/src/components/Notie.tsx
@@ -97,6 +97,7 @@ const Notie: React.FC<NotieProps> = ({
             const section = sections[sectionIndex];
             const definitions = section.getElementsByClassName("definition");
             const problems = section.getElementsByClassName("problem");
+            const algorithms = section.getElementsByClassName("algorithm");
             const theoremsAndLemmas =
                 section.querySelectorAll(".theorem, .lemma");
             for (let defIndex = 0; defIndex < definitions.length; defIndex++) {
@@ -111,6 +112,13 @@ const Notie: React.FC<NotieProps> = ({
                 prob.setAttribute(
                     "blockquote-problem-number",
                     `Problem ${sectionIndex + 1}.${probIndex + 1}`,
+                );
+            }
+            for (let algIndex = 0; algIndex < algorithms.length; algIndex++) {
+                const alg = algorithms[algIndex];
+                alg.setAttribute(
+                    "blockquote-algorithm-number",
+                    `Algorithm ${sectionIndex + 1}.${algIndex + 1}`,
                 );
             }
             theoremsAndLemmas.forEach((item, index) => {

--- a/src/styles/notie-global.css
+++ b/src/styles/notie-global.css
@@ -142,6 +142,17 @@ blockquote.lemma {
     border-left: 5px solid #486bd5;
 }
 
+/* Algorithm */
+blockquote.algorithm::before {
+    color: #486bd5;
+    content: "Algorithm";
+}
+
+blockquote.algorithm {
+    background: rgba(126, 174, 247, 0.2);
+    border-left: 5px solid #486bd5;
+}
+
 /* Important */
 blockquote.important::before {
     color: #dd2e2e;
@@ -222,6 +233,15 @@ blockquote.note {
 
 [style*="--blog-blockquote-style: latex"] blockquote.lemma::before {
     content: attr(blockquote-theorem-number) " ";
+    color: inherit;
+}
+
+[style*="--blog-blockquote-style: latex"] blockquote.algorithm {
+    font-style: normal;
+}
+
+[style*="--blog-blockquote-style: latex"] blockquote.algorithm::before {
+    content: attr(blockquote-algorithm-number) " ";
     color: inherit;
 }
 


### PR DESCRIPTION
## Summary

- Adds a new `algorithm` blockquote class styled in the same blue as `equation`, `theorem`, and `lemma` (`#486bd5` border, `rgba(126, 174, 247, 0.2)` background)
- Works in both **default** style (shows "Algorithm" label) and **latex** style (auto-numbered per section: Algorithm 1.1, 1.2, …)
- Auto-numbering wired into the existing `useEffect` in `Notie.tsx` alongside definitions, theorems, lemmas, and problems

**Usage:**
```html
<blockquote class="algorithm">

Step 1: ...
Step 2: ...

</blockquote>
```

## Test plan

- [ ] `npm run build` and `npm run lint` pass clean
- [ ] Default style: blockquote renders with blue left border and "Algorithm" label
- [ ] Latex style: blockquote renders with "Algorithm 1.1" numbering per section
- [ ] Color matches equation/theorem/lemma blockquotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)