### PR TITLE
feat: add blockquote reference and hover-preview system

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Check out the [tutorial](https://notie-markdown.vercel.app/tutorial) for more de
 - **TikZ Support**: Use TikZ to draw diagrams in your notes.
 - **Math Equations**: Write math equations using LaTeX syntax.
   - **Automatic Equation Numbering**: Automatically number equations and refer to them in your notes.
+- **Blockquote References**: Label definitions, theorems, lemmas, algorithms, and problems with an `id`, then reference them anywhere in the document with hover-preview tooltips.
 - **Customizable Themes**: Customize the appearance of your notes with different themes.
 
 ## Showcase

--- a/demo-app/src/assets/blockquote-reference.md
+++ b/demo-app/src/assets/blockquote-reference.md
@@ -1,0 +1,85 @@
+# Example: Blockquote References
+
+The source code for this markdown file can be found in [blockquote-reference.md](https://github.com/branyang02/notie/blob/main/demo-app/src/assets/blockquote-reference.md).
+
+## Overview
+
+**notie** supports hover-preview references for labeled blockquotes. Supported types are:
+`definition`, `theorem`, `lemma`, `algorithm`, and `problem`.
+
+## Defining a Labeled Blockquote
+
+Add an `id` attribute to any supported blockquote type:
+
+```html
+<blockquote class="definition" id="def:quadratic">
+
+A **quadratic equation** is a polynomial equation of degree 2 of the form
+$ax^2 + bx + c = 0$, where $a \neq 0$.
+
+</blockquote>
+```
+
+<blockquote class="definition" id="def:quadratic">
+
+A **quadratic equation** is a polynomial equation of degree 2 of the form $ax^2 + bx + c = 0$, where $a \neq 0$.
+
+</blockquote>
+
+## Referencing a Blockquote
+
+Use a Markdown link with the `#bqref-` prefix followed by the blockquote's `id`:
+
+```markdown
+See [Definition](#bqref-def:quadratic) for the definition of a quadratic equation.
+```
+
+See [Definition](#bqref-def:quadratic) for the definition of a quadratic equation. Hovering over the link shows a preview of the blockquote content. Clicking navigates to the blockquote itself.
+
+## Theorems and Lemmas
+
+Theorems and lemmas **share a counter** within each section, matching standard academic numbering convention.
+
+<blockquote class="theorem" id="thm:quadratic-formula">
+
+The solutions to a quadratic equation $ax^2 + bx + c = 0$ are given by:
+
+$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$
+
+</blockquote>
+
+<blockquote class="lemma" id="lem:discriminant">
+
+The **discriminant** $\Delta = b^2 - 4ac$ determines the nature of the roots: if $\Delta > 0$ there are two real roots, if $\Delta = 0$ there is one repeated root, and if $\Delta < 0$ there are two complex roots.
+
+</blockquote>
+
+[Theorem](#bqref-thm:quadratic-formula) gives the quadratic formula. [Lemma](#bqref-lem:discriminant) characterizes the roots based on the discriminant defined in [Definition](#bqref-def:quadratic).
+
+## Algorithms and Problems
+
+<blockquote class="algorithm" id="alg:binary-search">
+
+**Input:** Sorted array $A$, target value $t$
+
+1. Set $lo = 0$, $hi = |A| - 1$
+2. While $lo \leq hi$: let $mid = \lfloor (lo + hi) / 2 \rfloor$; if $A[mid] = t$ return $mid$; if $A[mid] < t$ set $lo = mid + 1$; else set $hi = mid - 1$
+3. Return $-1$
+
+</blockquote>
+
+<blockquote class="problem" id="prob:sorting">
+
+Given an unsorted array of $n$ integers, sort them in $O(n \log n)$ time.
+
+</blockquote>
+
+[Algorithm](#bqref-alg:binary-search) runs in $O(\log n)$ time and assumes the input satisfies [Problem](#bqref-prob:sorting).
+
+## Disabling Previews
+
+Set `previewBlockquotes: false` in the config to render plain links without tooltips:
+
+```tsx
+<Notie markdown={markdown} config={{ previewBlockquotes: false }} />
+```

--- a/demo-app/src/assets/blockquote-reference.md
+++ b/demo-app/src/assets/blockquote-reference.md
@@ -74,6 +74,37 @@ Given an unsorted array of $n$ integers, sort them in $O(n \log n)$ time.
 
 [Algorithm](#bqref-alg:binary-search) runs in $O(\log n)$ time and assumes the input satisfies [Problem](#bqref-prob:sorting).
 
+## Mixed: Blockquote and Equation References
+
+Blockquote references and equation references can be used together in the same section.
+
+<blockquote class="theorem" id="thm:pythagorean">
+
+For a right triangle with legs $a$, $b$ and hypotenuse $c$:
+
+$$
+\begin{equation} \label{eq:pythagoras}
+a^2 + b^2 = c^2
+\end{equation}
+$$
+
+</blockquote>
+
+<blockquote class="definition" id="def:dot-product">
+
+The **dot product** of two vectors $\mathbf{u}, \mathbf{v} \in \mathbb{R}^n$ is:
+
+$$
+\begin{align}
+\mathbf{u} \cdot \mathbf{v} &= \sum_{i=1}^{n} u_i v_i \label{eq:dot-sum} \\
+&= \|\mathbf{u}\| \|\mathbf{v}\| \cos\theta \label{eq:dot-cosine}
+\end{align}
+$$
+
+</blockquote>
+
+As shown in [Theorem](#bqref-thm:pythagorean), equation $\eqref{eq:pythagoras}$ holds for all right triangles. The two equivalent forms of the dot product are given by $\eqref{eq:dot-sum}$ and $\eqref{eq:dot-cosine}$, defined in [Definition](#bqref-def:dot-product).
+
 ## Disabling Previews
 
 Set `previewBlockquotes: false` in the config to render plain links without tooltips:

--- a/demo-app/src/assets/blockquote-reference.md
+++ b/demo-app/src/assets/blockquote-reference.md
@@ -13,10 +13,8 @@ Add an `id` attribute to any supported blockquote type:
 
 ```html
 <blockquote class="definition" id="def:quadratic">
-
-A **quadratic equation** is a polynomial equation of degree 2 of the form
-$ax^2 + bx + c = 0$, where $a \neq 0$.
-
+  A **quadratic equation** is a polynomial equation of degree 2 of the form
+  $ax^2 + bx + c = 0$, where $a \neq 0$.
 </blockquote>
 ```
 

--- a/demo-app/src/pages/tutorial.md
+++ b/demo-app/src/pages/tutorial.md
@@ -49,6 +49,7 @@ Notes:
 interface NotieConfig {
   showTableOfContents?: boolean;
   previewEquations?: boolean;
+  previewBlockquotes?: boolean;
   tocTitle?: string;
   fontSize?: CSSStyleDeclaration["fontSize"];
   theme?: Theme;
@@ -671,6 +672,9 @@ You can use the following classes to create different types of blocks:
 - `proof`
 - `equation`
 - `theorem`
+- `lemma`
+- `algorithm`
+- `problem`
 - `important`
 - `note`
 
@@ -702,11 +706,73 @@ $$
 
 </blockquote>
 
+<blockquote class="lemma">
+
+**Lemma.** This is a lemma.
+
+</blockquote>
+
+<blockquote class="algorithm">
+
+**Algorithm.** This is an algorithm.
+
+</blockquote>
+
+<blockquote class="problem">
+
+**Problem.** This is a problem.
+
+</blockquote>
+
 <blockquote class="note">
 
 **Note.** This is a note.
 
 </blockquote>
+
+### Blockquote References
+
+You can label a blockquote with an `id` attribute and reference it anywhere in the document using a `#bqref-` link. Supported types are `definition`, `theorem`, `lemma`, `algorithm`, and `problem`.
+
+```html
+<blockquote class="definition" id="def:limit">
+
+A **limit** is the value that a function approaches as the input approaches some value.
+
+</blockquote>
+
+See [Definition](#bqref-def:limit) for the formal definition.
+```
+
+<blockquote class="definition" id="def:limit">
+
+A **limit** is the value that a function approaches as the input approaches some value.
+
+</blockquote>
+
+See [Definition](#bqref-def:limit) for the formal definition. Hovering over the link shows a preview of the blockquote. Clicking navigates to it.
+
+Theorems and lemmas share a counter within each section:
+
+<blockquote class="theorem" id="thm:limit-uniqueness">
+
+If a limit exists, it is unique.
+
+</blockquote>
+
+<blockquote class="lemma" id="lem:squeeze">
+
+If $f(x) \leq g(x) \leq h(x)$ near $a$ and $\lim_{x \to a} f(x) = \lim_{x \to a} h(x) = L$, then $\lim_{x \to a} g(x) = L$.
+
+</blockquote>
+
+[Theorem](#bqref-thm:limit-uniqueness) guarantees uniqueness; [Lemma](#bqref-lem:squeeze) is useful for evaluating limits by comparison.
+
+To disable hover previews, set `previewBlockquotes: false` in the config:
+
+```tsx
+<Notie markdown={markdown} config={{ previewBlockquotes: false }} />
+```
 
 ## Collapsible Sections
 

--- a/demo-app/src/pages/tutorial.md
+++ b/demo-app/src/pages/tutorial.md
@@ -736,9 +736,8 @@ You can label a blockquote with an `id` attribute and reference it anywhere in t
 
 ```html
 <blockquote class="definition" id="def:limit">
-
-A **limit** is the value that a function approaches as the input approaches some value.
-
+  A **limit** is the value that a function approaches as the input approaches
+  some value.
 </blockquote>
 
 See [Definition](#bqref-def:limit) for the formal definition.

--- a/src/components/BlockquoteReference.tsx
+++ b/src/components/BlockquoteReference.tsx
@@ -106,7 +106,6 @@ const BlockquoteCard = ({
                 maxWidth: "400px",
                 fontFamily: "var(--blog-font-family)",
                 fontSize: "var(--blog-font-size)",
-                color: "var(--blog-text-color)",
             }}
         >
             <span

--- a/src/components/BlockquoteReference.tsx
+++ b/src/components/BlockquoteReference.tsx
@@ -70,7 +70,7 @@ const BlockquoteReference = ({
                 />
             }
             appearance="card"
-            statelessProps={{ maxWidth: "100%" }}
+            statelessProps={{ maxWidth: "100%", paddingX: 8, paddingY: 8 }}
         >
             <a href={`#${targetId}`}>
                 <span>{label}</span>
@@ -95,6 +95,7 @@ const BlockquoteCard = ({
     blockquoteType: string;
 }) => {
     const style = BLOCKQUOTE_STYLES[blockquoteType] ?? DEFAULT_STYLE;
+    const strippedContent = content.replace(/\\label\{[^}]*\}/g, "");
     return (
         <div
             style={{
@@ -124,7 +125,7 @@ const BlockquoteCard = ({
                 remarkPlugins={[remarkGfm, remarkMath]}
                 rehypePlugins={[[rehypeKatex]]}
             >
-                {content}
+                {strippedContent}
             </ReactMarkdown>
         </div>
     );

--- a/src/components/BlockquoteReference.tsx
+++ b/src/components/BlockquoteReference.tsx
@@ -4,10 +4,7 @@ import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 
-import {
-    BlockquoteMapping,
-    extractBlockquoteInfo,
-} from "../utils/utils";
+import { BlockquoteMapping, extractBlockquoteInfo } from "../utils/utils";
 
 interface BlockquoteStyle {
     background: string;
@@ -15,14 +12,26 @@ interface BlockquoteStyle {
 }
 
 const BLOCKQUOTE_STYLES: Record<string, BlockquoteStyle> = {
-    definition: { background: "rgba(174, 247, 126, 0.2)", labelColor: "#31dd2e" },
+    definition: {
+        background: "rgba(174, 247, 126, 0.2)",
+        labelColor: "#31dd2e",
+    },
     proof: { background: "rgba(174, 247, 126, 0.2)", labelColor: "#31dd2e" },
     theorem: { background: "rgba(126, 174, 247, 0.2)", labelColor: "#486bd5" },
     lemma: { background: "rgba(126, 174, 247, 0.2)", labelColor: "#486bd5" },
-    algorithm: { background: "rgba(126, 174, 247, 0.2)", labelColor: "#486bd5" },
+    algorithm: {
+        background: "rgba(126, 174, 247, 0.2)",
+        labelColor: "#486bd5",
+    },
     problem: { background: "rgba(126, 174, 247, 0.2)", labelColor: "#486bd5" },
-    important: { background: "rgba(247, 126, 126, 0.2)", labelColor: "#dd2e2e" },
-    note: { background: "rgb(255 253 0 / 19%)", labelColor: "lch(86 109.24 91.22)" },
+    important: {
+        background: "rgba(247, 126, 126, 0.2)",
+        labelColor: "#dd2e2e",
+    },
+    note: {
+        background: "rgb(255 253 0 / 19%)",
+        labelColor: "lch(86 109.24 91.22)",
+    },
 };
 
 const DEFAULT_STYLE: BlockquoteStyle = {
@@ -43,18 +52,13 @@ const BlockquoteReference = ({
         extractBlockquoteInfo(children, blockquoteMapping);
 
     if (blockquoteContent === "error") {
-        return (
-            <span style={{ color: "red" }}>{blockquoteNumber}</span>
-        );
+        return <span style={{ color: "red" }}>{blockquoteNumber}</span>;
     }
 
     const displayType =
         blockquoteType.charAt(0).toUpperCase() + blockquoteType.slice(1);
     const label = `${displayType} ${blockquoteNumber}`;
-    const targetId = children
-        .getAttribute("href")
-        ?.split("#bqref-")
-        .pop();
+    const targetId = children.getAttribute("href")?.split("#bqref-").pop();
 
     return previewBlockquotes ? (
         <Tooltip

--- a/src/components/BlockquoteReference.tsx
+++ b/src/components/BlockquoteReference.tsx
@@ -1,0 +1,128 @@
+import { Tooltip } from "evergreen-ui";
+import ReactMarkdown from "react-markdown";
+import rehypeKatex from "rehype-katex";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+
+import {
+    BlockquoteMapping,
+    extractBlockquoteInfo,
+} from "../utils/utils";
+
+interface BlockquoteStyle {
+    background: string;
+    labelColor: string;
+}
+
+const BLOCKQUOTE_STYLES: Record<string, BlockquoteStyle> = {
+    definition: { background: "rgba(174, 247, 126, 0.2)", labelColor: "#31dd2e" },
+    proof: { background: "rgba(174, 247, 126, 0.2)", labelColor: "#31dd2e" },
+    theorem: { background: "rgba(126, 174, 247, 0.2)", labelColor: "#486bd5" },
+    lemma: { background: "rgba(126, 174, 247, 0.2)", labelColor: "#486bd5" },
+    algorithm: { background: "rgba(126, 174, 247, 0.2)", labelColor: "#486bd5" },
+    problem: { background: "rgba(126, 174, 247, 0.2)", labelColor: "#486bd5" },
+    important: { background: "rgba(247, 126, 126, 0.2)", labelColor: "#dd2e2e" },
+    note: { background: "rgb(255 253 0 / 19%)", labelColor: "lch(86 109.24 91.22)" },
+};
+
+const DEFAULT_STYLE: BlockquoteStyle = {
+    background: "rgba(126, 174, 247, 0.2)",
+    labelColor: "#486bd5",
+};
+
+const BlockquoteReference = ({
+    children,
+    blockquoteMapping,
+    previewBlockquotes,
+}: {
+    children: Element;
+    blockquoteMapping: BlockquoteMapping;
+    previewBlockquotes?: boolean;
+}) => {
+    const { blockquoteNumber, blockquoteType, blockquoteContent } =
+        extractBlockquoteInfo(children, blockquoteMapping);
+
+    if (blockquoteContent === "error") {
+        return (
+            <span style={{ color: "red" }}>{blockquoteNumber}</span>
+        );
+    }
+
+    const displayType =
+        blockquoteType.charAt(0).toUpperCase() + blockquoteType.slice(1);
+    const label = `${displayType} ${blockquoteNumber}`;
+    const targetId = children
+        .getAttribute("href")
+        ?.split("#bqref-")
+        .pop();
+
+    return previewBlockquotes ? (
+        <Tooltip
+            content={
+                <BlockquoteCard
+                    label={label}
+                    content={blockquoteContent}
+                    blockquoteType={blockquoteType}
+                />
+            }
+            appearance="card"
+            statelessProps={{ maxWidth: "100%" }}
+        >
+            <a href={`#${targetId}`}>
+                <span>{label}</span>
+            </a>
+        </Tooltip>
+    ) : (
+        <a href={`#${targetId}`}>
+            <span>{label}</span>
+        </a>
+    );
+};
+
+export default BlockquoteReference;
+
+const BlockquoteCard = ({
+    label,
+    content,
+    blockquoteType,
+}: {
+    label: string;
+    content: string;
+    blockquoteType: string;
+}) => {
+    const style = BLOCKQUOTE_STYLES[blockquoteType] ?? DEFAULT_STYLE;
+    return (
+        <div
+            style={{
+                background: style.background,
+                borderRadius: "5px",
+                paddingLeft: "0.8rem",
+                paddingRight: "0.8rem",
+                paddingBottom: "0.9em",
+                maxWidth: "400px",
+                fontFamily: "var(--blog-font-family)",
+                fontSize: "var(--blog-font-size)",
+                color: "var(--blog-text-color)",
+            }}
+        >
+            <span
+                style={{
+                    display: "block",
+                    fontWeight: "bold",
+                    textTransform: "uppercase",
+                    fontSize: "0.85em",
+                    paddingTop: "0.9rem",
+                    color: style.labelColor,
+                }}
+            >
+                {label}.
+            </span>
+            <ReactMarkdown
+                remarkPlugins={[remarkGfm, remarkMath]}
+                rehypePlugins={[[rehypeKatex]]}
+            >
+                {content}
+            </ReactMarkdown>
+        </div>
+    );
+};

--- a/src/components/BlockquoteReference.tsx
+++ b/src/components/BlockquoteReference.tsx
@@ -103,7 +103,7 @@ const BlockquoteCard = ({
                 paddingLeft: "0.8rem",
                 paddingRight: "0.8rem",
                 paddingBottom: "0.9em",
-                maxWidth: "400px",
+                maxWidth: "800px",
                 fontFamily: "var(--blog-font-family)",
                 fontSize: "var(--blog-font-size)",
             }}

--- a/src/components/Notie.tsx
+++ b/src/components/Notie.tsx
@@ -31,10 +31,11 @@ const Notie: React.FC<NotieProps> = ({
     customComponents,
 }) => {
     const config = useNotieConfig(userConfig, theme);
-    const { markdownContent, equationMapping, blockquoteMapping } = useMemo(() => {
-        const processor = new MarkdownProcessor(markdown, config);
-        return processor.process();
-    }, [markdown, config]);
+    const { markdownContent, equationMapping, blockquoteMapping } =
+        useMemo(() => {
+            const processor = new MarkdownProcessor(markdown, config);
+            return processor.process();
+        }, [markdown, config]);
     const contentRef = useRef<HTMLDivElement>(null);
     const [activeId, setActiveId] = useState<string>("");
 
@@ -162,9 +163,8 @@ const Notie: React.FC<NotieProps> = ({
     // Effect to enable Blockquote Preview
     useEffect(() => {
         if (!contentRef.current) return;
-        const bqRefs = contentRef.current.querySelectorAll(
-            'a[href^="#bqref-"]',
-        );
+        const bqRefs =
+            contentRef.current.querySelectorAll('a[href^="#bqref-"]');
 
         bqRefs.forEach((ref) => {
             const bqReference = document.createElement("span");

--- a/src/components/Notie.tsx
+++ b/src/components/Notie.tsx
@@ -9,6 +9,7 @@ import ScrollToTopButton from "./ScrollToTopButton";
 import NoteToc from "./NotieToc";
 import MarkdownRenderer from "./MarkdownRenderer";
 import { MarkdownProcessor } from "../utils/MarkdownProcessor";
+import BlockquoteReference from "./BlockquoteReference";
 import EquationReference from "./EquationReference";
 import { createRoot } from "react-dom/client";
 import { NotieConfig, NotieThemes } from "../config/NotieConfig";
@@ -30,7 +31,7 @@ const Notie: React.FC<NotieProps> = ({
     customComponents,
 }) => {
     const config = useNotieConfig(userConfig, theme);
-    const { markdownContent, equationMapping } = useMemo(() => {
+    const { markdownContent, equationMapping, blockquoteMapping } = useMemo(() => {
         const processor = new MarkdownProcessor(markdown, config);
         return processor.process();
     }, [markdown, config]);
@@ -157,6 +158,27 @@ const Notie: React.FC<NotieProps> = ({
             ref.parentNode?.replaceChild(equReference, ref);
         });
     }, [config.previewEquations, equationMapping]);
+
+    // Effect to enable Blockquote Preview
+    useEffect(() => {
+        if (!contentRef.current) return;
+        const bqRefs = contentRef.current.querySelectorAll(
+            'a[href^="#bqref-"]',
+        );
+
+        bqRefs.forEach((ref) => {
+            const bqReference = document.createElement("span");
+            const bqReferenceComponent = (
+                <BlockquoteReference
+                    children={ref}
+                    blockquoteMapping={blockquoteMapping}
+                    previewBlockquotes={config.previewBlockquotes}
+                />
+            );
+            createRoot(bqReference).render(bqReferenceComponent);
+            ref.parentNode?.replaceChild(bqReference, ref);
+        });
+    }, [config.previewBlockquotes, blockquoteMapping]);
 
     return (
         <Pane className={styles["notie-container"]}>

--- a/src/config/NotieConfig.tsx
+++ b/src/config/NotieConfig.tsx
@@ -42,6 +42,7 @@ export interface Theme {
 export interface NotieConfig {
     showTableOfContents?: boolean;
     previewEquations?: boolean;
+    previewBlockquotes?: boolean;
     tocTitle?: string;
     fontSize?: CSSStyleDeclaration["fontSize"];
     theme?: Theme;

--- a/src/dev/test.md
+++ b/src/dev/test.md
@@ -128,6 +128,35 @@ The roots can be computed using [Theorem](#bqref-thm:quadratic-formula).
 [Lemma](#bqref-lem:discriminant) characterizes the root types based on the discriminant.
 Efficient search is described in [Algorithm](#bqref-alg:binary-search).
 
+### Mixed: Blockquote and Equation References
+
+<blockquote class="theorem" id="thm:pythagorean">
+
+For a right triangle with legs $a$, $b$ and hypotenuse $c$:
+
+$$
+\begin{equation} \label{eq:pythagoras}
+a^2 + b^2 = c^2
+\end{equation}
+$$
+
+</blockquote>
+
+<blockquote class="definition" id="def:dot-product">
+
+The **dot product** of two vectors $\mathbf{u}, \mathbf{v} \in \mathbb{R}^n$ is:
+
+$$
+\begin{align}
+\mathbf{u} \cdot \mathbf{v} &= \sum_{i=1}^{n} u_i v_i \label{eq:dot-sum} \\
+&= \|\mathbf{u}\| \|\mathbf{v}\| \cos\theta \label{eq:dot-cosine}
+\end{align}
+$$
+
+</blockquote>
+
+As shown in [Theorem](#bqref-thm:pythagorean), equation $\eqref{eq:pythagoras}$ holds for all right triangles. The two equivalent forms of the dot product are $\eqref{eq:dot-sum}$ and $\eqref{eq:dot-cosine}$, defined in [Definition](#bqref-def:dot-product).
+
 ### Running Code
 
 ```execute-python

--- a/src/dev/test.md
+++ b/src/dev/test.md
@@ -91,6 +91,43 @@ Let's reference equations $\eqref{eq:dot-product}$, $\eqref{eq:2x2-determinant}$
 
 Let's also reference $\eqref{eq:gauss-law}$, $\eqref{eq:ampere-maxwell}$, $\eqref{eq:energy-equation}$, and $\eqref{eq:einstein-field}$
 
+### Blockquote References
+
+<blockquote class="definition" id="def:quadratic">
+
+A **quadratic equation** is a polynomial equation of degree 2 of the form $ax^2 + bx + c = 0$, where $a \neq 0$.
+
+</blockquote>
+
+<blockquote class="theorem" id="thm:quadratic-formula">
+
+The solutions to a quadratic equation $ax^2 + bx + c = 0$ are given by:
+
+$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$
+
+</blockquote>
+
+<blockquote class="lemma" id="lem:discriminant">
+
+The **discriminant** $\Delta = b^2 - 4ac$ determines the nature of the roots: if $\Delta > 0$ there are two real roots, if $\Delta = 0$ there is one repeated root, and if $\Delta < 0$ there are two complex roots.
+
+</blockquote>
+
+<blockquote class="algorithm" id="alg:binary-search">
+
+**Input:** Sorted array $A$, target value $t$
+
+1. Set $lo = 0$, $hi = |A| - 1$
+2. While $lo \leq hi$: let $mid = \lfloor (lo + hi) / 2 \rfloor$; if $A[mid] = t$ return $mid$; if $A[mid] < t$ set $lo = mid + 1$; else set $hi = mid - 1$
+3. Return $-1$
+
+</blockquote>
+
+As established in [Definition](#bqref-def:quadratic), a quadratic equation has degree 2.
+The roots can be computed using [Theorem](#bqref-thm:quadratic-formula).
+[Lemma](#bqref-lem:discriminant) characterizes the root types based on the discriminant.
+Efficient search is described in [Algorithm](#bqref-alg:binary-search).
+
 ### Running Code
 
 ```execute-python

--- a/src/styles/notie-global.css
+++ b/src/styles/notie-global.css
@@ -153,6 +153,17 @@ blockquote.algorithm {
     border-left: 5px solid #486bd5;
 }
 
+/* Problem */
+blockquote.problem::before {
+    color: #486bd5;
+    content: "Problem";
+}
+
+blockquote.problem {
+    background: rgba(126, 174, 247, 0.2);
+    border-left: 5px solid #486bd5;
+}
+
 /* Important */
 blockquote.important::before {
     color: #dd2e2e;
@@ -254,7 +265,6 @@ blockquote.note {
 }
 
 [style*="--blog-blockquote-style: latex"] blockquote.problem {
-    all: unset;
     font-style: normal;
 }
 

--- a/src/utils/MarkdownProcessor.ts
+++ b/src/utils/MarkdownProcessor.ts
@@ -1,10 +1,11 @@
 import { NotieConfig } from "../config/NotieConfig";
-import { EquationMapping } from "./utils";
+import { BlockquoteMapping, EquationMapping } from "./utils";
 
 export class MarkdownProcessor {
     private markdownContent: string;
     private config: NotieConfig;
     private equationMapping: EquationMapping = {};
+    private blockquoteMapping: BlockquoteMapping = {};
 
     constructor(markdownContent: string, config: NotieConfig) {
         this.markdownContent = markdownContent;
@@ -14,6 +15,7 @@ export class MarkdownProcessor {
     public process(): {
         markdownContent: string;
         equationMapping: EquationMapping;
+        blockquoteMapping: BlockquoteMapping;
     } {
         const sections = this.splitIntoSections();
         const processedSections = sections.map((section, i) => {
@@ -28,12 +30,14 @@ export class MarkdownProcessor {
             return {
                 markdownContent: processedMarkdown,
                 equationMapping: this.equationMapping,
+                blockquoteMapping: this.blockquoteMapping,
             };
         }
 
         return {
             markdownContent: processedSections.join(""),
             equationMapping: this.equationMapping,
+            blockquoteMapping: this.blockquoteMapping,
         };
     }
 
@@ -72,7 +76,56 @@ export class MarkdownProcessor {
             modifiedContent,
             sectionIndex,
         );
+        this.processBlockquotes(modifiedContent, sectionIndex);
         return this.reinsertCodeBlocks(finalContent, codeBlocks);
+    }
+
+    private processBlockquotes(content: string, sectionIndex: number): void {
+        const tagPattern = /<blockquote\b([^>]*)>/g;
+        const SUPPORTED = [
+            "definition",
+            "theorem",
+            "lemma",
+            "algorithm",
+            "problem",
+        ];
+        const counts: Record<string, number> = {};
+
+        let tagMatch;
+        while ((tagMatch = tagPattern.exec(content)) !== null) {
+            const attrs = tagMatch[1];
+            const classAttr =
+                attrs.match(/\bclass="([^"]+)"/)?.[1] ?? "";
+            const idAttr = attrs.match(/\bid="([^"]+)"/)?.[1];
+
+            if (!idAttr) continue;
+
+            const type = SUPPORTED.find((t) => classAttr.includes(t));
+            if (!type) continue;
+
+            // Theorems and lemmas share a counter (mirrors DOM useEffect)
+            const counterKey = type === "lemma" ? "theorem" : type;
+            counts[counterKey] = (counts[counterKey] ?? 0) + 1;
+
+            const blockquoteNumber = `${sectionIndex}.${counts[counterKey]}`;
+
+            const contentStart = tagMatch.index + tagMatch[0].length;
+            const endIndex = content.indexOf("</blockquote>", contentStart);
+            const rawContent =
+                endIndex !== -1
+                    ? content.slice(contentStart, endIndex).trim()
+                    : "";
+
+            if (idAttr in this.blockquoteMapping) {
+                console.error(`Duplicate blockquote id found: ${idAttr}.`);
+            } else {
+                this.blockquoteMapping[idAttr] = {
+                    blockquoteNumber,
+                    blockquoteType: type,
+                    blockquoteContent: rawContent,
+                };
+            }
+        }
     }
 
     private processEquations(content: string, sectionIndex: number): string {

--- a/src/utils/MarkdownProcessor.ts
+++ b/src/utils/MarkdownProcessor.ts
@@ -94,8 +94,7 @@ export class MarkdownProcessor {
         let tagMatch;
         while ((tagMatch = tagPattern.exec(content)) !== null) {
             const attrs = tagMatch[1];
-            const classAttr =
-                attrs.match(/\bclass="([^"]+)"/)?.[1] ?? "";
+            const classAttr = attrs.match(/\bclass="([^"]+)"/)?.[1] ?? "";
             const idAttr = attrs.match(/\bid="([^"]+)"/)?.[1];
 
             if (!idAttr) continue;

--- a/src/utils/useNotieConfig.ts
+++ b/src/utils/useNotieConfig.ts
@@ -145,6 +145,7 @@ const defaultTheme: FullTheme = {
 const defaultNotieConfig: FullNotieConfig = {
     showTableOfContents: true,
     previewEquations: true,
+    previewBlockquotes: true,
     tocTitle: "Contents",
     fontSize: "1rem",
     theme: defaultTheme,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,35 @@
+export interface BlockquoteMapping {
+    [label: string]: {
+        blockquoteNumber: string;
+        blockquoteType: string;
+        blockquoteContent: string;
+    };
+}
+
+export function extractBlockquoteInfo(
+    children: Element,
+    blockquoteMapping: BlockquoteMapping,
+) {
+    const href = children.getAttribute("href");
+    const label = href?.split("#bqref-").pop();
+    if (!label) throw new Error("No blockquote label found");
+
+    if (!(label in blockquoteMapping)) {
+        console.error(
+            `Blockquote label "${label}" not found in blockquote mapping`,
+        );
+        return {
+            blockquoteNumber: `Error: reference ${label} not labeled`,
+            blockquoteType: "unknown",
+            blockquoteContent: "error",
+        };
+    }
+
+    const { blockquoteNumber, blockquoteType, blockquoteContent } =
+        blockquoteMapping[label];
+    return { blockquoteNumber, blockquoteType, blockquoteContent };
+}
+
 export interface EquationMapping {
     [key: string]: {
         equationNumber: string;


### PR DESCRIPTION
## Summary

- Adds labeled blockquote references for `definition`, `theorem`, `lemma`, `algorithm`, and `problem` types
- Reference links use a `#bqref-<id>` prefix and render as auto-numbered labels (e.g. "Definition 1.1") with optional hover-preview tooltips
- Tooltip previews match blockquote background colors and inherit document fonts/text color
- Mirrors the existing equation reference system architecture (`MarkdownProcessor` builds a mapping at parse time; a `useEffect` in `Notie.tsx` intercepts matching links in the DOM)
- Adds `previewBlockquotes` config option (default `true`) to opt out of tooltips
- Adds a demo page (`blockquote-reference.md`) and updates README

## Test plan

- [x] Add a labeled blockquote and a `[text](#bqref-<id>)` link — renders as "Type X.Y" with correct numbering
- [x] Hover over the reference link — tooltip shows blockquote content with matching background color and fonts
- [x] Click the link — navigates to the blockquote in the page
- [x] Set `previewBlockquotes: false` — renders plain link with no tooltip
- [x] Theorem + lemma references share a counter and number correctly
- [x] Invalid `#bqref-` id renders in red
- [x] `npm run build` and `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)