### PR TITLE
fix: blockquote reference numbers out of sync with rendered numbers

### DIFF
--- a/src/utils/MarkdownProcessor.ts
+++ b/src/utils/MarkdownProcessor.ts
@@ -97,14 +97,15 @@ export class MarkdownProcessor {
             const classAttr = attrs.match(/\bclass="([^"]+)"/)?.[1] ?? "";
             const idAttr = attrs.match(/\bid="([^"]+)"/)?.[1];
 
-            if (!idAttr) continue;
-
             const type = SUPPORTED.find((t) => classAttr.includes(t));
             if (!type) continue;
 
             // Theorems and lemmas share a counter (mirrors DOM useEffect)
             const counterKey = type === "lemma" ? "theorem" : type;
             counts[counterKey] = (counts[counterKey] ?? 0) + 1;
+
+            // Only store in mapping if this blockquote has a label id
+            if (!idAttr) continue;
 
             const blockquoteNumber = `${sectionIndex}.${counts[counterKey]}`;
 


### PR DESCRIPTION
## Summary

- **Bug**: A blockquote reference (e.g. `[see alg](#bqref-alg:foo)`) would render as "Algorithm 5.1" while the actual blockquote displayed "Algorithm 5.5", whenever unlabeled blockquotes of the same type preceded the labeled one in the same section.
- **Root cause**: `MarkdownProcessor.processBlockquotes` skipped incrementing the counter for blockquotes without an `id`, but `Notie.tsx`'s DOM `useEffect` counts *all* blockquotes regardless of whether they have a label — causing the two numbering systems to diverge.
- **Fix**: Move the `!idAttr` guard to after the counter increment, so the counter advances for every supported blockquote type (matching DOM behavior), and the mapping is only written when an `id` is present.

## Test plan

- [ ] A labeled blockquote preceded by unlabeled blockquotes of the same type in the same section: reference number matches the rendered blockquote number
- [ ] Labeled blockquote with no preceding unlabeled blockquotes: still numbered correctly (no regression)
- [ ] Mixed types in a section (e.g. definition, theorem, algorithm): each type's counter is independent and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)