### PR TITLE
Improve large markdown rendering performance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tgz
 
 # Editor directories and files
 .vscode/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
                 "vite-plugin-dts": "^4.0.0-beta.2"
             },
             "devDependencies": {
+                "@testing-library/jest-dom": "^6.9.1",
+                "@testing-library/react": "^16.3.2",
                 "@types/react": "^18.3.3",
                 "@types/react-dom": "^18.3.0",
                 "@typescript-eslint/eslint-plugin": "^7.15.0",
@@ -39,11 +41,21 @@
                 "eslint": "^8.57.0",
                 "eslint-plugin-react-hooks": "^4.6.2",
                 "eslint-plugin-react-refresh": "^0.4.7",
+                "jsdom": "^29.1.1",
                 "prettier": "^3.3.3",
                 "prettier-plugin-organize-imports": "^4.0.0",
+                "tsx": "^4.21.0",
                 "typescript": "^5.2.2",
-                "vite": "^5.3.4"
+                "vite": "^5.3.4",
+                "vitest": "^4.1.5"
             }
+        },
+        "node_modules/@adobe/css-tools": {
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+            "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.3.0",
@@ -58,6 +70,57 @@
             "engines": {
                 "node": ">=6.0.0"
             }
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+            "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.2.1",
+                "is-potential-custom-element-name": "^1.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/generational-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.24.7",
@@ -389,6 +452,19 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
+            }
+        },
         "node_modules/@codemirror/autocomplete": {
             "version": "6.18.0",
             "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.0.tgz",
@@ -482,6 +558,180 @@
                 "@codemirror/state": "^6.4.0",
                 "style-mod": "^4.1.0",
                 "w3c-keyname": "^2.2.4"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+            "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+            "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+            "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.0.2",
+                "@csstools/css-calc": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+            "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@emotion/hash": {
@@ -762,6 +1012,23 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/netbsd-x64": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -778,6 +1045,23 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/openbsd-x64": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -792,6 +1076,23 @@
             ],
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/sunos-x64": {
@@ -958,6 +1259,24 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+            "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.14",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -1056,9 +1375,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -1239,6 +1558,25 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "license": "MIT"
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1277,6 +1615,16 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@oxc-project/types": {
+            "version": "0.127.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+            "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -1287,6 +1635,270 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
             }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+            "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+            "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+            "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@rollup/pluginutils": {
             "version": "5.1.0",
@@ -1796,11 +2408,113 @@
             "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
             "license": "MIT"
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@testing-library/jest-dom": {
+            "version": "6.9.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+            "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@adobe/css-tools": "^4.4.0",
+                "aria-query": "^5.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.6.3",
+                "picocolors": "^1.1.1",
+                "redent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+            "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@testing-library/react": {
+            "version": "16.3.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+            "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^18.0.0 || ^19.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@types/argparse": {
             "version": "1.0.38",
             "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
             "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
             "license": "MIT"
+        },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -1847,6 +2561,17 @@
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
         "node_modules/@types/debug": {
             "version": "4.1.12",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1855,6 +2580,13 @@
             "dependencies": {
                 "@types/ms": "*"
             }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.5",
@@ -2223,6 +2955,106 @@
                 "vite": "^4.2.0 || ^5.0.0"
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+            "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+            "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+            "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.5",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+            "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+            "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+            "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.5",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@volar/language-core": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.3.4.tgz",
@@ -2447,6 +3279,16 @@
             "dev": true,
             "license": "Python-2.0"
         },
+        "node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
+        },
         "node_modules/array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -2466,6 +3308,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/bail": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -2481,6 +3333,16 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "license": "MIT"
+        },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
+            }
         },
         "node_modules/bootstrap": {
             "version": "5.3.3",
@@ -2595,6 +3457,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -2782,11 +3654,46 @@
                 "isobject": "^3.0.1"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "license": "MIT"
+        },
+        "node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
         },
         "node_modules/de-indent": {
             "version": "1.0.2",
@@ -2810,6 +3717,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/decode-named-character-reference": {
             "version": "1.0.2",
@@ -2838,6 +3752,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "devOptional": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/devlop": {
@@ -2878,6 +3802,14 @@
             "engines": {
                 "node": ">=6.0.0"
             }
+        },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/dom-helpers": {
             "version": "5.2.1",
@@ -2928,6 +3860,13 @@
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/esbuild": {
             "version": "0.21.5",
@@ -3338,6 +4277,16 @@
                 "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3533,6 +4482,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/get-tsconfig": {
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+            "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
         "node_modules/github-slugger": {
@@ -3976,6 +4938,19 @@
                 "he": "bin/he"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/html-url-attributes": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.0.tgz",
@@ -4055,6 +5030,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/inflight": {
@@ -4205,6 +5190,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4244,6 +5236,83 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsdom": {
+            "version": "29.1.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+            "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^5.1.11",
+                "@asamuzakjp/dom-selector": "^7.1.1",
+                "@bramus/specificity": "^2.4.2",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+                "@exodus/bytes": "^1.15.0",
+                "css-tree": "^3.2.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.3.5",
+                "parse5": "^8.0.1",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.1",
+                "undici": "^7.25.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.1",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/jsdom/node_modules/lru-cache": {
+            "version": "11.3.6",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+            "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/jsdom/node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "node_modules/jsesc": {
@@ -4346,6 +5415,267 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "devOptional": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/local-pkg": {
@@ -4454,13 +5784,24 @@
                 "yallist": "^3.0.2"
             }
         },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
         "node_modules/magic-string": {
-            "version": "0.30.11",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
-            "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
             "license": "MIT",
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.5.0"
+                "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
         "node_modules/markdown-table": {
@@ -4773,6 +6114,13 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -5380,6 +6728,16 @@
                 "node": ">=8.6"
             }
         },
+        "node_modules/min-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/minimatch": {
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -5420,9 +6778,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "funding": [
                 {
                     "type": "github",
@@ -5459,6 +6817,17 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
         },
         "node_modules/once": {
             "version": "1.4.0",
@@ -5647,9 +7016,9 @@
             "license": "MIT"
         },
         "node_modules/picocolors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -5673,6 +7042,34 @@
                 "confbox": "^0.1.7",
                 "mlly": "^1.7.1",
                 "pathe": "^1.1.2"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/prelude-ls": {
@@ -5721,6 +7118,44 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/pretty-format/node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/prop-types": {
             "version": "15.8.1",
@@ -5867,6 +7302,20 @@
             "peerDependencies": {
                 "react": ">=16.6.0",
                 "react-dom": ">=16.6.0"
+            }
+        },
+        "node_modules/redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/regenerator-runtime": {
@@ -6068,6 +7517,16 @@
                 "node": ">=4"
             }
         },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
         "node_modules/reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -6094,6 +7553,40 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+            "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.127.0",
+                "@rolldown/pluginutils": "1.0.0-rc.17"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
             }
         },
         "node_modules/rollup": {
@@ -6153,6 +7646,19 @@
             "license": "MIT",
             "dependencies": {
                 "queue-microtask": "^1.2.2"
+            }
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
             }
         },
         "node_modules/scheduler": {
@@ -6218,6 +7724,13 @@
                 "node": ">=20"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6238,9 +7751,9 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -6261,6 +7774,20 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "license": "BSD-3-Clause"
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string-argv": {
             "version": "0.3.2",
@@ -6293,6 +7820,19 @@
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "min-indent": "^1.0.0"
             },
             "engines": {
                 "node": ">=8"
@@ -6350,10 +7890,112 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+            "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tldts": {
+            "version": "7.0.30",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+            "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.0.30"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.0.30",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+            "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -6377,6 +8019,32 @@
             },
             "engines": {
                 "node": ">=8.0"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/trim-lines": {
@@ -6410,6 +8078,467 @@
             },
             "peerDependencies": {
                 "typescript": ">=4.2.0"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
+        "node_modules/tsx": {
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+            "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "~0.27.0",
+                "get-tsconfig": "^4.7.5"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/esbuild": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
             }
         },
         "node_modules/type-check": {
@@ -6472,6 +8601,16 @@
             },
             "peerDependencies": {
                 "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/undici": {
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
@@ -6785,32 +8924,741 @@
                 }
             }
         },
-        "node_modules/vite/node_modules/postcss": {
-            "version": "8.4.41",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
-            "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
+        "node_modules/vitest": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+            "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.0.1",
-                "source-map-js": "^1.2.0"
+                "@vitest/expect": "4.1.5",
+                "@vitest/mocker": "4.1.5",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/runner": "4.1.5",
+                "@vitest/snapshot": "4.1.5",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14"
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.5",
+                "@vitest/browser-preview": "4.1.5",
+                "@vitest/browser-webdriverio": "4.1.5",
+                "@vitest/coverage-istanbul": "4.1.5",
+                "@vitest/coverage-v8": "4.1.5",
+                "@vitest/ui": "4.1.5",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-arm": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+            "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.5",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/esbuild": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+            "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.0",
+                "@esbuild/android-arm": "0.28.0",
+                "@esbuild/android-arm64": "0.28.0",
+                "@esbuild/android-x64": "0.28.0",
+                "@esbuild/darwin-arm64": "0.28.0",
+                "@esbuild/darwin-x64": "0.28.0",
+                "@esbuild/freebsd-arm64": "0.28.0",
+                "@esbuild/freebsd-x64": "0.28.0",
+                "@esbuild/linux-arm": "0.28.0",
+                "@esbuild/linux-arm64": "0.28.0",
+                "@esbuild/linux-ia32": "0.28.0",
+                "@esbuild/linux-loong64": "0.28.0",
+                "@esbuild/linux-mips64el": "0.28.0",
+                "@esbuild/linux-ppc64": "0.28.0",
+                "@esbuild/linux-riscv64": "0.28.0",
+                "@esbuild/linux-s390x": "0.28.0",
+                "@esbuild/linux-x64": "0.28.0",
+                "@esbuild/netbsd-arm64": "0.28.0",
+                "@esbuild/netbsd-x64": "0.28.0",
+                "@esbuild/openbsd-arm64": "0.28.0",
+                "@esbuild/openbsd-x64": "0.28.0",
+                "@esbuild/openharmony-arm64": "0.28.0",
+                "@esbuild/sunos-x64": "0.28.0",
+                "@esbuild/win32-arm64": "0.28.0",
+                "@esbuild/win32-ia32": "0.28.0",
+                "@esbuild/win32-x64": "0.28.0"
+            }
+        },
+        "node_modules/vitest/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/vitest/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest/node_modules/vite": {
+            "version": "8.0.10",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+            "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.10",
+                "rolldown": "1.0.0-rc.17",
+                "tinyglobby": "^0.2.16"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
             }
         },
         "node_modules/vscode-uri": {
@@ -6868,6 +9716,19 @@
             "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
             "license": "MIT"
         },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/web-namespaces": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -6876,6 +9737,41 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/which": {
@@ -6894,6 +9790,23 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/word-wrap": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6910,6 +9823,23 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/yallist": {
             "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
         "dev": "vite",
         "build": "tsc -b && vite build",
         "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+        "test": "vitest run",
+        "benchmark": "tsx scripts/benchmark-notie.tsx",
         "format": "prettier --write .",
         "preview": "vite preview"
     },
@@ -40,9 +42,8 @@
         "@shikijs/themes": "^4.0.2",
         "@types/node": "^22.1.0",
         "@uiw/react-codemirror": "^4.23.0",
-        "codemirror-shiki": "^0.3.0",
-        "shiki": "^4.0.2",
         "bootstrap": "^5.3.3",
+        "codemirror-shiki": "^0.3.0",
         "evergreen-ui": "^7.1.9",
         "katex": "^0.16.11",
         "react": "^18.3.1",
@@ -53,10 +54,13 @@
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
+        "shiki": "^4.0.2",
         "vite-plugin-css-injected-by-js": "^3.5.1",
         "vite-plugin-dts": "^4.0.0-beta.2"
     },
     "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.15.0",
@@ -65,9 +69,12 @@
         "eslint": "^8.57.0",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.7",
+        "jsdom": "^29.1.1",
         "prettier": "^3.3.3",
         "prettier-plugin-organize-imports": "^4.0.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.2.2",
-        "vite": "^5.3.4"
+        "vite": "^5.3.4",
+        "vitest": "^4.1.5"
     }
 }

--- a/scripts/benchmark-notie.tsx
+++ b/scripts/benchmark-notie.tsx
@@ -1,0 +1,145 @@
+import fs from "node:fs";
+import { performance } from "node:perf_hooks";
+import React from "react";
+import { renderToString } from "react-dom/server";
+import rehypeKatex from "rehype-katex";
+import rehypeRaw from "rehype-raw";
+import rehypeSlug from "rehype-slug";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import { MarkdownProcessor } from "../src/utils/MarkdownProcessor";
+import { FullNotieConfig } from "../src/config/NotieConfig";
+import { katexOptions } from "../src/utils/katexOptions";
+
+const notePath = process.env.NOTIE_BENCHMARK_MARKDOWN;
+
+const config: FullNotieConfig = {
+    showTableOfContents: true,
+    previewEquations: true,
+    previewBlockquotes: true,
+    tocTitle: "Contents",
+    fontSize: "1.05em",
+    theme: {
+        appearance: "light",
+        backgroundColor: "rgb(245, 244, 239)",
+        fontFamily: '"Computer Modern Serif", serif',
+        customFontUrl:
+            "https://cdn.jsdelivr.net/gh/bitmaks/cm-web-fonts@latest/fonts.css",
+        titleColor: "#000",
+        textColor: "#000",
+        linkColor: "#36f",
+        linkHoverColor: "#0056b3",
+        linkUnderline: false,
+        tocFontFamily: "",
+        tocCustomFontUrl: "",
+        tocColor: "#000",
+        tocHoverColor: "#777",
+        tocUnderline: false,
+        codeColor: "#000",
+        codeBackgroundColor: "#fafafa",
+        codeHeaderColor: "rgba(175, 184, 193, 0.2)",
+        codeFontSize: "medium",
+        codeCopyButtonHoverColor: "#F4F5F9",
+        staticCodeTheme: "github-light",
+        liveCodeTheme: "github-light",
+        collapseSectionColor: "#f0f0f0",
+        katexSize: "1.21rem",
+        tableBorderColor: "#ddd",
+        tableBackgroundColor: "#f2f2f2",
+        captionColor: "#555",
+        subtitleColor: "#969696",
+        tikZstyle: "default",
+        blockquoteStyle: "latex",
+        numberedHeading: true,
+        tocMarker: false,
+    },
+};
+
+function measure<T>(label: string, fn: () => T): T {
+    const start = performance.now();
+    const result = fn();
+    const duration = performance.now() - start;
+    console.log(`${label}: ${duration.toFixed(1)}ms`);
+    return result;
+}
+
+function renderMarkdown(markdownContent: string) {
+    return renderToString(
+        <ReactMarkdown
+            remarkPlugins={[remarkGfm, remarkMath]}
+            rehypePlugins={[[rehypeKatex, katexOptions], rehypeRaw, rehypeSlug]}
+        >
+            {markdownContent}
+        </ReactMarkdown>,
+    );
+}
+
+function createSyntheticMarkdown(sectionCount = 80): string {
+    const sections = Array.from({ length: sectionCount }, (_, index) => {
+        const sectionNumber = index + 1;
+        return `## Section ${sectionNumber}
+
+This section references $\\eqref{eq:synthetic-${sectionNumber}}$ and [Algorithm](#bqref-alg:synthetic-${sectionNumber}).
+
+$$
+\\begin{equation} \\label{eq:synthetic-${sectionNumber}}
+x_${sectionNumber} = \\sum_{j=0}^{${sectionNumber}} \\gamma^j r_j
+\\end{equation}
+$$
+
+<blockquote class="algorithm" id="alg:synthetic-${sectionNumber}">
+
+Use $\\eqref{eq:synthetic-${sectionNumber}}$ as the update target.
+
+</blockquote>
+
+~~~tsx
+export function Example${sectionNumber}() {
+    return <div>Section ${sectionNumber}</div>;
+}
+~~~
+`;
+    });
+
+    return `# Synthetic Benchmark Note
+
+${sections.join("\n")}
+`;
+}
+
+const markdown = notePath
+    ? fs.readFileSync(notePath, "utf8")
+    : createSyntheticMarkdown();
+
+console.log(notePath ? `file: ${notePath}` : "file: synthetic benchmark");
+console.log(
+    `size: ${(markdown.length / 1024).toFixed(1)} KiB, lines: ${
+        markdown.split("\n").length
+    }`,
+);
+
+const processed = measure("processor", () =>
+    new MarkdownProcessor(markdown, config).process(),
+);
+
+measure("full markdown renderToString", () =>
+    renderMarkdown(processed.markdownContent),
+);
+
+if ("markdownSections" in processed && processed.markdownSections.length > 0) {
+    measure("first section renderToString", () =>
+        renderMarkdown(processed.markdownSections[0]),
+    );
+    measure("initial visible sections renderToString", () => {
+        for (const section of processed.markdownSections.slice(0, 2)) {
+            renderMarkdown(section);
+        }
+    });
+    measure("all sections renderToString", () => {
+        for (const section of processed.markdownSections) {
+            renderMarkdown(section);
+        }
+    });
+    console.log(`sections: ${processed.markdownSections.length}`);
+}

--- a/src/components/BlockquoteReference.tsx
+++ b/src/components/BlockquoteReference.tsx
@@ -1,10 +1,17 @@
 import { Tooltip } from "evergreen-ui";
+import React, { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 
-import { BlockquoteMapping, extractBlockquoteInfo } from "../utils/utils";
+import { katexOptions } from "../utils/katexOptions";
+import {
+    BlockquoteMapping,
+    EquationMapping,
+    extractBlockquoteInfo,
+} from "../utils/utils";
+import EquationReference from "./EquationReference";
 
 interface BlockquoteStyle {
     background: string;
@@ -40,16 +47,20 @@ const DEFAULT_STYLE: BlockquoteStyle = {
 };
 
 const BlockquoteReference = ({
-    children,
+    href,
     blockquoteMapping,
+    equationMapping,
     previewBlockquotes,
+    previewEquations,
 }: {
-    children: Element;
+    href: string;
     blockquoteMapping: BlockquoteMapping;
+    equationMapping: EquationMapping;
     previewBlockquotes?: boolean;
+    previewEquations?: boolean;
 }) => {
     const { blockquoteNumber, blockquoteType, blockquoteContent } =
-        extractBlockquoteInfo(children, blockquoteMapping);
+        extractBlockquoteInfo(href, blockquoteMapping);
 
     if (blockquoteContent === "error") {
         return <span style={{ color: "red" }}>{blockquoteNumber}</span>;
@@ -58,7 +69,7 @@ const BlockquoteReference = ({
     const displayType =
         blockquoteType.charAt(0).toUpperCase() + blockquoteType.slice(1);
     const label = `${displayType} ${blockquoteNumber}`;
-    const targetId = children.getAttribute("href")?.split("#bqref-").pop();
+    const targetId = href.split("#bqref-").pop();
 
     return previewBlockquotes ? (
         <Tooltip
@@ -67,6 +78,8 @@ const BlockquoteReference = ({
                     label={label}
                     content={blockquoteContent}
                     blockquoteType={blockquoteType}
+                    equationMapping={equationMapping}
+                    previewEquations={previewEquations}
                 />
             }
             appearance="card"
@@ -89,13 +102,48 @@ const BlockquoteCard = ({
     label,
     content,
     blockquoteType,
+    equationMapping,
+    previewEquations,
 }: {
     label: string;
     content: string;
     blockquoteType: string;
+    equationMapping: EquationMapping;
+    previewEquations?: boolean;
 }) => {
     const style = BLOCKQUOTE_STYLES[blockquoteType] ?? DEFAULT_STYLE;
     const strippedContent = content.replace(/\\label\{[^}]*\}/g, "");
+    const components = useMemo(
+        () => ({
+            a({
+                href = "",
+                children,
+                ...props
+            }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+                node?: unknown;
+                children?: React.ReactNode;
+            }) {
+                if (href.startsWith("#pre-eqn-")) {
+                    return (
+                        <EquationReference
+                            href={href}
+                            textContent={textFromReactNode(children)}
+                            equationMapping={equationMapping}
+                            previewEquation={previewEquations}
+                        />
+                    );
+                }
+
+                return (
+                    <a href={href} {...props}>
+                        {children}
+                    </a>
+                );
+            },
+        }),
+        [equationMapping, previewEquations],
+    );
+
     return (
         <div
             style={{
@@ -123,10 +171,24 @@ const BlockquoteCard = ({
             </span>
             <ReactMarkdown
                 remarkPlugins={[remarkGfm, remarkMath]}
-                rehypePlugins={[[rehypeKatex]]}
+                rehypePlugins={[[rehypeKatex, katexOptions]]}
+                components={components}
             >
                 {strippedContent}
             </ReactMarkdown>
         </div>
     );
 };
+
+function textFromReactNode(node: React.ReactNode): string {
+    if (typeof node === "string" || typeof node === "number") {
+        return String(node);
+    }
+    if (Array.isArray(node)) {
+        return node.map(textFromReactNode).join("");
+    }
+    if (React.isValidElement<{ children?: React.ReactNode }>(node)) {
+        return textFromReactNode(node.props.children);
+    }
+    return "";
+}

--- a/src/components/DesmosGraph.tsx
+++ b/src/components/DesmosGraph.tsx
@@ -5,32 +5,54 @@ import styles from "../styles/Notie.module.css";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const Desmos: any;
 
+let desmosScriptPromise: Promise<void> | null = null;
+
+function loadDesmosScript(): Promise<void> {
+    if (typeof Desmos !== "undefined") return Promise.resolve();
+
+    if (!desmosScriptPromise) {
+        desmosScriptPromise = new Promise((resolve, reject) => {
+            const scriptEl = document.createElement("script");
+            scriptEl.src =
+                "https://www.desmos.com/api/v1.9/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6";
+            scriptEl.async = true;
+            scriptEl.onload = () => resolve();
+            scriptEl.onerror = () =>
+                reject(new Error("Failed to load Desmos script"));
+            document.head.appendChild(scriptEl);
+        });
+    }
+
+    return desmosScriptPromise;
+}
+
 const DesmosGraph = ({ graphScript }: { graphScript: string }) => {
     const calculatorRef = useRef<HTMLDivElement | null>(null);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const calculatorInstance = useRef<any>(null); // Store the Desmos instance
-    const scriptLoaded = useRef(false); // Track if the script is loaded
 
     useEffect(() => {
-        if (!scriptLoaded.current) {
-            const scriptEl = document.createElement("script");
-            const apiUrl =
-                "https://www.desmos.com/api/v1.9/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6";
-            scriptEl.src = apiUrl;
-            scriptEl.async = true;
-            scriptEl.onload = () => {
-                scriptLoaded.current = true;
+        let cancelled = false;
+
+        loadDesmosScript()
+            .then(() => {
+                if (cancelled) return;
                 if (calculatorRef.current && !calculatorInstance.current) {
                     calculatorInstance.current = Desmos.GraphingCalculator(
                         calculatorRef.current,
                     );
+                    updateExpressions();
                 }
-                updateExpressions(); // Initial update
-            };
-            document.head.appendChild(scriptEl);
-        }
+            })
+            .catch((error) => console.error(error));
+
+        return () => {
+            cancelled = true;
+            calculatorInstance.current?.destroy?.();
+            calculatorInstance.current = null;
+        };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []); // Empty dependency array ensures this only runs once
+    }, []);
 
     // Update the calculator when graphScript changes
     useEffect(() => {

--- a/src/components/EquationReference.tsx
+++ b/src/components/EquationReference.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
+import { katexOptions } from "../utils/katexOptions";
 import {
     EquationMapping,
     extractEquationInfo,
@@ -10,16 +11,18 @@ import {
 } from "../utils/utils";
 
 const EquationReference = ({
-    children,
+    href,
+    textContent,
     equationMapping,
     previewEquation,
 }: {
-    children: Element;
+    href: string;
+    textContent?: string;
     equationMapping: EquationMapping;
     previewEquation?: boolean;
 }) => {
     const { equationNumber, equationString, parenthesesRemoved } =
-        extractEquationInfo(children, equationMapping);
+        extractEquationInfo(href, textContent, equationMapping);
 
     if (equationString == "error") {
         return (
@@ -63,7 +66,7 @@ const EquationCard = ({ equationString }: { equationString: string }) => {
         <Card>
             <ReactMarkdown
                 remarkPlugins={[remarkGfm, remarkMath]}
-                rehypePlugins={[[rehypeKatex]]}
+                rehypePlugins={[[rehypeKatex, katexOptions]]}
             >
                 {processedEquationString}
             </ReactMarkdown>

--- a/src/components/LazyRender.tsx
+++ b/src/components/LazyRender.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useRef, useState } from "react";
+
+const DEFAULT_ROOT_MARGIN = "600px 0px";
+
+const LazyRender = ({
+    children,
+    minHeight = 160,
+    rootMargin = DEFAULT_ROOT_MARGIN,
+}: {
+    children: React.ReactNode;
+    minHeight?: number;
+    rootMargin?: string;
+}) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [shouldRender, setShouldRender] = useState(() => {
+        if (typeof window === "undefined") return true;
+        return !("IntersectionObserver" in window);
+    });
+
+    useEffect(() => {
+        if (shouldRender) return;
+        const container = containerRef.current;
+        if (!container) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((entry) => entry.isIntersecting)) {
+                    setShouldRender(true);
+                    observer.disconnect();
+                }
+            },
+            { rootMargin },
+        );
+
+        observer.observe(container);
+        return () => observer.disconnect();
+    }, [rootMargin, shouldRender]);
+
+    return (
+        <div
+            ref={containerRef}
+            style={shouldRender ? undefined : { minHeight }}
+        >
+            {shouldRender ? children : null}
+        </div>
+    );
+};
+
+export default LazyRender;

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1,16 +1,21 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
+import { katexOptions } from "../utils/katexOptions";
+import { BlockquoteMapping, EquationMapping } from "../utils/utils";
+import BlockquoteReference from "./BlockquoteReference";
 import CodeBlock from "./CodeBlock";
-import TikZ from "./TikZ";
-import StaticCodeBlock from "./StaticCodeBlock";
-import { FullNotieConfig } from "../config/NotieConfig";
-import { InlineAlert } from "evergreen-ui";
 import DesmosGraph from "./DesmosGraph";
+import EquationReference from "./EquationReference";
+import { InlineAlert } from "evergreen-ui";
+import LazyRender from "./LazyRender";
+import StaticCodeBlock from "./StaticCodeBlock";
+import TikZ from "./TikZ";
+import { FullNotieConfig } from "../config/NotieConfig";
 
 type CodeProps = React.HTMLAttributes<HTMLElement> & {
     node?: unknown;
@@ -23,100 +28,298 @@ type CustomComponentFormat = {
     componentName: string;
 };
 
+type AnchorProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    node?: unknown;
+    children?: React.ReactNode;
+};
+
+const INITIAL_SECTION_COUNT = 2;
+
+function textFromReactNode(node: React.ReactNode): string {
+    if (typeof node === "string" || typeof node === "number") {
+        return String(node);
+    }
+    if (Array.isArray(node)) {
+        return node.map(textFromReactNode).join("");
+    }
+    if (React.isValidElement<{ children?: React.ReactNode }>(node)) {
+        return textFromReactNode(node.props.children);
+    }
+    return "";
+}
+
+function getInitialSectionCount(sectionCount: number): number {
+    if (typeof window === "undefined") return sectionCount;
+    return Math.min(INITIAL_SECTION_COUNT, sectionCount);
+}
+
+function getDocumentSignature(sections: string[]): string {
+    const headings: string[] = [];
+
+    for (const section of sections) {
+        const matches = section.matchAll(/^#{1,6}\s+(.+)$/gm);
+        for (const match of matches) {
+            headings.push(match[1].trim());
+            if (headings.length >= 3) {
+                return headings.join("\n");
+            }
+        }
+    }
+
+    return sections[0]?.slice(0, 120) ?? "";
+}
+
+function scheduleNextSection(callback: () => void): () => void {
+    if (typeof window === "undefined") return () => {};
+
+    if (typeof window.requestIdleCallback === "function") {
+        const idleId = window.requestIdleCallback(callback, { timeout: 250 });
+        return () => window.cancelIdleCallback(idleId);
+    }
+
+    const timeoutId = globalThis.setTimeout(callback, 16);
+    return () => globalThis.clearTimeout(timeoutId);
+}
+
 const MarkdownRenderer: React.FC<{
     markdownContent: string;
+    markdownSections?: string[];
     config: FullNotieConfig;
+    equationMapping: EquationMapping;
+    blockquoteMapping: BlockquoteMapping;
     customComponents?: {
         [key: string]: () => JSX.Element;
     };
-}> = React.memo(({ markdownContent, config, customComponents }) => {
-    const components = useMemo(
-        () => ({
-            code({ inline, className, children, ...props }: CodeProps) {
-                const match = /\w+/.exec(className || "");
+    renderAllToken?: number;
+    onRenderedSectionsChange?: (renderedSectionCount: number) => void;
+}> = React.memo(
+    ({
+        markdownContent,
+        markdownSections,
+        config,
+        equationMapping,
+        blockquoteMapping,
+        customComponents,
+        renderAllToken,
+        onRenderedSectionsChange,
+    }) => {
+        const sections = useMemo(
+            () =>
+                markdownSections && markdownSections.length > 0
+                    ? markdownSections
+                    : [markdownContent],
+            [markdownContent, markdownSections],
+        );
+        const [visibleSectionCount, setVisibleSectionCount] = useState(() =>
+            getInitialSectionCount(sections.length),
+        );
+        const documentSignature = useMemo(
+            () => getDocumentSignature(sections),
+            [sections],
+        );
+        const previousSectionsRef = useRef(sections);
+        const previousDocumentSignatureRef = useRef(documentSignature);
+        const previousRenderAllTokenRef = useRef(renderAllToken);
+        const sectionsChanged = previousSectionsRef.current !== sections;
+        const sameDocument =
+            previousDocumentSignatureRef.current === documentSignature;
+        const initialSectionCount = getInitialSectionCount(sections.length);
+        const targetVisibleSectionCount =
+            sectionsChanged && !sameDocument
+                ? initialSectionCount
+                : Math.max(visibleSectionCount, initialSectionCount);
+        const effectiveVisibleSectionCount = Math.min(
+            targetVisibleSectionCount,
+            sections.length,
+        );
 
-                if (!inline && match) {
-                    const language = className?.split("language-").pop() || "";
-                    const content = Array.isArray(children)
-                        ? children.join("")
-                        : children;
-                    const code = String(content).replace(/\n$/, "");
-                    if (language.includes("execute-")) {
+        useEffect(() => {
+            if (!sectionsChanged) return;
+            const shouldPreserveRenderedSections =
+                previousDocumentSignatureRef.current === documentSignature;
+
+            previousSectionsRef.current = sections;
+            previousDocumentSignatureRef.current = documentSignature;
+            setVisibleSectionCount((current) =>
+                shouldPreserveRenderedSections
+                    ? Math.min(
+                          Math.max(current, initialSectionCount),
+                          sections.length,
+                      )
+                    : initialSectionCount,
+            );
+        }, [documentSignature, initialSectionCount, sections, sectionsChanged]);
+
+        useEffect(() => {
+            if (previousRenderAllTokenRef.current === renderAllToken) return;
+            previousRenderAllTokenRef.current = renderAllToken;
+            setVisibleSectionCount(sections.length);
+        }, [renderAllToken, sections.length]);
+
+        useEffect(() => {
+            onRenderedSectionsChange?.(effectiveVisibleSectionCount);
+        }, [effectiveVisibleSectionCount, onRenderedSectionsChange]);
+
+        useEffect(() => {
+            if (
+                sectionsChanged ||
+                effectiveVisibleSectionCount >= sections.length
+            ) {
+                return;
+            }
+
+            return scheduleNextSection(() => {
+                setVisibleSectionCount((current) =>
+                    Math.min(current + 1, sections.length),
+                );
+            });
+        }, [effectiveVisibleSectionCount, sections.length, sectionsChanged]);
+
+        const components = useMemo(
+            () => ({
+                a({ href = "", children, ...props }: AnchorProps) {
+                    if (href.startsWith("#pre-eqn-")) {
                         return (
-                            <CodeBlock
-                                initialCode={code}
-                                language={language.split("-").pop()}
-                                theme={config.theme.liveCodeTheme}
+                            <EquationReference
+                                href={href}
+                                textContent={textFromReactNode(children)}
+                                equationMapping={equationMapping}
+                                previewEquation={config.previewEquations}
                             />
                         );
                     }
-                    if (language === "tikz") {
-                        return <TikZ tikzScript={code} />;
-                    }
-                    if (language === "desmos") {
-                        return <DesmosGraph graphScript={code} />;
-                    }
-                    if (language === "component") {
-                        if (!customComponents) {
-                            return (
-                                <InlineAlert intent="danger">
-                                    You need to pass `customComponents` to
-                                    render component code block.
-                                </InlineAlert>
-                            );
-                        }
-                        const jsonString = code.replace(/(\w+):/g, '"$1":');
-                        const componentConfig = JSON.parse(
-                            jsonString,
-                        ) as CustomComponentFormat;
 
-                        const CustomComponent =
-                            customComponents[componentConfig.componentName];
-
-                        if (CustomComponent) {
-                            return <CustomComponent />;
-                        } else {
-                            return (
-                                <InlineAlert intent="danger">
-                                    {`We couldn't find your component \`${componentConfig.componentName}\`.`}
-                                </InlineAlert>
-                            );
-                        }
+                    if (href.startsWith("#bqref-")) {
+                        return (
+                            <BlockquoteReference
+                                href={href}
+                                blockquoteMapping={blockquoteMapping}
+                                equationMapping={equationMapping}
+                                previewBlockquotes={config.previewBlockquotes}
+                                previewEquations={config.previewEquations}
+                            />
+                        );
                     }
+
                     return (
-                        <StaticCodeBlock
-                            code={code}
-                            language={language}
-                            theme={config.theme.staticCodeTheme}
-                        />
-                    );
-                } else {
-                    return (
-                        <code className={className} {...props}>
+                        <a href={href} {...props}>
                             {children}
-                        </code>
+                        </a>
                     );
-                }
-            },
-        }),
-        [
-            config.theme.liveCodeTheme,
-            config.theme.staticCodeTheme,
-            customComponents,
-        ],
-    );
+                },
+                code({ inline, className, children, ...props }: CodeProps) {
+                    const match = /\w+/.exec(className || "");
 
-    const katexOptions = {
-        macros: {
-            "\\eqref": "\\href{\\#pre-eqn-#1}{(#1)}",
-            "\\ref": "\\href{\\#pre-eqn-#1}{#1}",
-            "\\label": "\\htmlId{#1}{}",
-        },
-        trust: (context: { command: string }) =>
-            ["\\htmlId", "\\href"].includes(context.command),
-    };
+                    if (!inline && match) {
+                        const language =
+                            className?.split("language-").pop() || "";
+                        const content = Array.isArray(children)
+                            ? children.join("")
+                            : children;
+                        const code = String(content).replace(/\n$/, "");
+                        if (language.includes("execute-")) {
+                            return (
+                                <LazyRender minHeight={260}>
+                                    <CodeBlock
+                                        initialCode={code}
+                                        language={language.split("-").pop()}
+                                        theme={config.theme.liveCodeTheme}
+                                    />
+                                </LazyRender>
+                            );
+                        }
+                        if (language === "tikz") {
+                            return (
+                                <LazyRender minHeight={220}>
+                                    <TikZ tikzScript={code} />
+                                </LazyRender>
+                            );
+                        }
+                        if (language === "desmos") {
+                            return (
+                                <LazyRender minHeight={400}>
+                                    <DesmosGraph graphScript={code} />
+                                </LazyRender>
+                            );
+                        }
+                        if (language === "component") {
+                            if (!customComponents) {
+                                return (
+                                    <InlineAlert intent="danger">
+                                        You need to pass `customComponents` to
+                                        render component code block.
+                                    </InlineAlert>
+                                );
+                            }
+                            const jsonString = code.replace(/(\w+):/g, '"$1":');
+                            const componentConfig = JSON.parse(
+                                jsonString,
+                            ) as CustomComponentFormat;
 
-    return (
+                            const CustomComponent =
+                                customComponents[componentConfig.componentName];
+
+                            if (CustomComponent) {
+                                return <CustomComponent />;
+                            } else {
+                                return (
+                                    <InlineAlert intent="danger">
+                                        {`We couldn't find your component \`${componentConfig.componentName}\`.`}
+                                    </InlineAlert>
+                                );
+                            }
+                        }
+                        return (
+                            <StaticCodeBlock
+                                code={code}
+                                language={language}
+                                theme={config.theme.staticCodeTheme}
+                            />
+                        );
+                    } else {
+                        return (
+                            <code className={className} {...props}>
+                                {children}
+                            </code>
+                        );
+                    }
+                },
+            }),
+            [
+                blockquoteMapping,
+                config.previewBlockquotes,
+                config.previewEquations,
+                config.theme.liveCodeTheme,
+                config.theme.staticCodeTheme,
+                customComponents,
+                equationMapping,
+            ],
+        );
+
+        return (
+            <>
+                {sections
+                    .slice(0, effectiveVisibleSectionCount)
+                    .map((section, index) => (
+                        <MarkdownSection
+                            key={index}
+                            markdownContent={section}
+                            components={components}
+                        />
+                    ))}
+            </>
+        );
+    },
+);
+
+const MarkdownSection = React.memo(
+    ({
+        markdownContent,
+        components,
+    }: {
+        markdownContent: string;
+        components: React.ComponentProps<typeof ReactMarkdown>["components"];
+    }) => (
         <ReactMarkdown
             remarkPlugins={[remarkGfm, remarkMath]}
             rehypePlugins={[[rehypeKatex, katexOptions], rehypeRaw, rehypeSlug]}
@@ -124,7 +327,7 @@ const MarkdownRenderer: React.FC<{
         >
             {markdownContent}
         </ReactMarkdown>
-    );
-});
+    ),
+);
 
 export default MarkdownRenderer;

--- a/src/components/Notie.test.tsx
+++ b/src/components/Notie.test.tsx
@@ -1,0 +1,298 @@
+import {
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+    within,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import Notie from "./Notie";
+
+describe("Notie", () => {
+    beforeEach(() => {
+        window.history.replaceState(null, "", "/");
+    });
+
+    it("renders markdown, TOC, equations, blockquote references, and custom components", async () => {
+        const { container } = render(
+            <Notie
+                markdown={`# Demo
+
+## First Section
+
+$$
+\\begin{equation} \\label{eq:first}
+x = 1
+\\end{equation}
+$$
+
+See $\\eqref{eq:first}$.
+
+<blockquote class="definition" id="def:first">
+Reusable definition.
+</blockquote>
+
+See [definition](#bqref-def:first).
+
+\`\`\`component
+{
+    componentName: "Widget"
+}
+\`\`\`
+`}
+                config={{
+                    theme: {
+                        blockquoteStyle: "latex",
+                        numberedHeading: true,
+                    },
+                }}
+                customComponents={{
+                    Widget: () => <div data-testid="custom-widget">Widget</div>,
+                }}
+            />,
+        );
+
+        expect(
+            screen.getByRole("heading", { name: /Demo/i }),
+        ).toBeInTheDocument();
+        expect(screen.getByTestId("custom-widget")).toHaveTextContent("Widget");
+        expect(screen.getByText("Definition 1.1")).toBeInTheDocument();
+
+        const toc = screen.getByRole("navigation", { name: /contents/i });
+        expect(within(toc).getByText(/First Section/)).toBeInTheDocument();
+
+        const equationReference = container.querySelector('a[href="#eqn-1.1"]');
+        expect(equationReference).toHaveTextContent("(1.1)");
+        expect(container.querySelector("#eqn-1\\.1")).toHaveTextContent(
+            "(1.1)",
+        );
+
+        const blockquoteReference = screen
+            .getAllByRole("link")
+            .find((link) => link.getAttribute("href") === "#def:first");
+        expect(blockquoteReference).toHaveTextContent("Definition 1.1");
+    });
+
+    it("renders equation references whose labels contain underscores", () => {
+        const { container } = render(
+            <Notie
+                markdown={`# Demo
+
+## First Section
+
+$$
+\\begin{equation} \\label{eq:k_step_q_estimate}
+\\hat{Q}^{(k)}(s_t, a_t) = r_t + \\gamma V_\\phi(s_{t+1})
+\\end{equation}
+$$
+
+See $\\eqref{eq:k_step_q_estimate}$ and $\\ref{eq:k_step_q_estimate}$.
+`}
+            />,
+        );
+
+        const references = Array.from(
+            container.querySelectorAll('a[href="#eqn-1.1"]'),
+        );
+        expect(references.map((ref) => ref.textContent)).toEqual([
+            "(1.1)",
+            "1.1",
+        ]);
+        expect(container.querySelector("#eqn-1\\.1")).toHaveTextContent(
+            "(1.1)",
+        );
+        expect(container.querySelector(".katex-error")).not.toBeInTheDocument();
+    });
+
+    it("resolves equation references inside blockquote preview cards", async () => {
+        const { container } = render(
+            <Notie
+                markdown={`# Demo
+
+## First Section
+
+$$
+\\begin{equation} \\label{eq:k_step_q_estimate}
+\\hat{Q}^{(k)}(s_t, a_t) = r_t + \\gamma V_\\phi(s_{t+1})
+\\end{equation}
+$$
+
+<blockquote class="algorithm" id="alg:critic-target">
+
+Use $\\eqref{eq:k_step_q_estimate}$ as the critic target.
+
+</blockquote>
+
+See [Algorithm](#bqref-alg:critic-target).
+`}
+                config={{
+                    theme: {
+                        blockquoteStyle: "latex",
+                    },
+                }}
+            />,
+        );
+
+        const algorithmReference = screen.getByRole("link", {
+            name: "Algorithm 1.1",
+        });
+        fireEvent.mouseEnter(algorithmReference);
+
+        await waitFor(() => {
+            const equationReferences = Array.from(
+                container.querySelectorAll('a[href="#eqn-1.1"]'),
+            );
+            expect(
+                equationReferences.some((link) => link.textContent === "(1.1)"),
+            ).toBe(true);
+        });
+        expect(container.querySelector(".katex-error")).not.toBeInTheDocument();
+    });
+
+    it("renders large notes progressively while preserving TOC navigation", async () => {
+        render(
+            <Notie
+                markdown={`# Demo
+
+## One
+
+First section.
+
+## Two
+
+Second section.
+
+## Three
+
+Third section.
+`}
+            />,
+        );
+
+        expect(screen.getByText("First section.")).toBeInTheDocument();
+        expect(screen.queryByText("Third section.")).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("link", { name: "Three" }));
+
+        await waitFor(() => {
+            expect(screen.getByText("Third section.")).toBeInTheDocument();
+        });
+    });
+
+    it("rerenders when markdown content changes", () => {
+        const { rerender } = render(
+            <Notie markdown={"# Original\n\n## Section\n\nOriginal body."} />,
+        );
+
+        expect(screen.getByText("Original body.")).toBeInTheDocument();
+
+        rerender(
+            <Notie markdown={"# Updated\n\n## Section\n\nUpdated body."} />,
+        );
+
+        expect(screen.getByText("Updated body.")).toBeInTheDocument();
+        expect(screen.queryByText("Original body.")).not.toBeInTheDocument();
+    });
+
+    it("keeps already rendered lower sections mounted across markdown updates", async () => {
+        const { rerender } = render(
+            <Notie
+                markdown={`# Demo
+
+## One
+
+First section.
+
+## Two
+
+Second section.
+
+## Three
+
+Original third section.
+`}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("Original third section."),
+            ).toBeInTheDocument();
+        });
+
+        rerender(
+            <Notie
+                markdown={`# Demo
+
+## One
+
+First section.
+
+## Two
+
+Second section.
+
+## Three
+
+Updated third section.
+`}
+            />,
+        );
+
+        expect(screen.getByText("Updated third section.")).toBeInTheDocument();
+        expect(
+            screen.queryByText("Original third section."),
+        ).not.toBeInTheDocument();
+    });
+
+    it("resets progressive rendering when markdown changes to a different document", async () => {
+        const { rerender } = render(
+            <Notie
+                markdown={`# Demo
+
+## One
+
+First section.
+
+## Two
+
+Second section.
+
+## Three
+
+Original third section.
+`}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("Original third section."),
+            ).toBeInTheDocument();
+        });
+
+        rerender(
+            <Notie
+                markdown={`# Different Demo
+
+## Alpha
+
+Alpha section.
+
+## Beta
+
+Beta section.
+
+## Gamma
+
+New third section.
+`}
+            />,
+        );
+
+        expect(screen.getByText("Alpha section.")).toBeInTheDocument();
+        expect(
+            screen.queryByText("New third section."),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/src/components/Notie.tsx
+++ b/src/components/Notie.tsx
@@ -3,17 +3,21 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import styles from "../styles//Notie.module.css";
 import "../styles/notie-global.css";
 
-import React, { useRef, useState, useEffect, useMemo } from "react";
+import React, {
+    useCallback,
+    useRef,
+    useState,
+    useEffect,
+    useMemo,
+} from "react";
 import { Pane } from "evergreen-ui";
 import ScrollToTopButton from "./ScrollToTopButton";
 import NoteToc from "./NotieToc";
 import MarkdownRenderer from "./MarkdownRenderer";
 import { MarkdownProcessor } from "../utils/MarkdownProcessor";
-import BlockquoteReference from "./BlockquoteReference";
-import EquationReference from "./EquationReference";
-import { createRoot } from "react-dom/client";
 import { NotieConfig, NotieThemes } from "../config/NotieConfig";
 import { useNotieConfig } from "../utils/useNotieConfig";
+import { extractTableOfContents } from "../utils/toc";
 
 export interface NotieProps {
     markdown: string;
@@ -31,13 +35,66 @@ const Notie: React.FC<NotieProps> = ({
     customComponents,
 }) => {
     const config = useNotieConfig(userConfig, theme);
-    const { markdownContent, equationMapping, blockquoteMapping } =
-        useMemo(() => {
-            const processor = new MarkdownProcessor(markdown, config);
-            return processor.process();
-        }, [markdown, config]);
+    const {
+        markdownContent,
+        markdownSections,
+        equationMapping,
+        blockquoteMapping,
+    } = useMemo(() => {
+        const processor = new MarkdownProcessor(markdown, config);
+        return processor.process();
+    }, [markdown, config]);
+    const tocEntries = useMemo(
+        () => extractTableOfContents(markdownContent),
+        [markdownContent],
+    );
     const contentRef = useRef<HTMLDivElement>(null);
     const [activeId, setActiveId] = useState<string>("");
+    const [renderedSectionCount, setRenderedSectionCount] = useState(0);
+    const [renderAllToken, setRenderAllToken] = useState(0);
+    const [pendingScrollId, setPendingScrollId] = useState<string | null>(null);
+    const handleRenderedSectionsChange = useCallback(
+        (count: number) => setRenderedSectionCount(count),
+        [],
+    );
+    const requestRenderAll = useCallback(() => {
+        setRenderAllToken((token) => token + 1);
+    }, []);
+    const handleTocNavigate = useCallback(
+        (id: string, event: React.MouseEvent<HTMLAnchorElement>) => {
+            if (document.getElementById(id)) return;
+
+            event.preventDefault();
+            setPendingScrollId(id);
+            requestRenderAll();
+        },
+        [requestRenderAll],
+    );
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        const hash = window.location.hash.slice(1);
+        if (!hash) return;
+
+        const id = decodeURIComponent(hash);
+        if (document.getElementById(id)) return;
+
+        setPendingScrollId(id);
+        requestRenderAll();
+    }, [markdownContent, requestRenderAll]);
+
+    useEffect(() => {
+        if (!pendingScrollId || typeof window === "undefined") return;
+
+        const target = document.getElementById(pendingScrollId);
+        if (!target) return;
+
+        target.scrollIntoView();
+        if (window.location.hash !== `#${pendingScrollId}`) {
+            window.history.pushState(null, "", `#${pendingScrollId}`);
+        }
+        setPendingScrollId(null);
+    }, [pendingScrollId, renderedSectionCount]);
 
     // Effect to observe headings and update activeId
     useEffect(() => {
@@ -53,17 +110,16 @@ const Notie: React.FC<NotieProps> = ({
         const observer = new IntersectionObserver((entries) => {
             entries.forEach((entry) => {
                 if (entry.isIntersecting) {
-                    setActiveId(entry.target.id);
+                    const id = entry.target.id;
+                    setActiveId((current) => (current === id ? current : id));
                 }
             });
         }, observerOptions);
 
         headings.forEach((heading) => observer.observe(heading));
 
-        return () => {
-            headings.forEach((heading) => observer.unobserve(heading));
-        };
-    }, [markdownContent, activeId]);
+        return () => observer.disconnect();
+    }, [markdownContent, renderedSectionCount]);
 
     // Effect to auto label equation numbers
     useEffect(() => {
@@ -83,7 +139,7 @@ const Notie: React.FC<NotieProps> = ({
                 eqn.textContent = `(${sectionIndex + 1}.${eqnIndex + 1})`;
             }
         }
-    }, [markdownContent]);
+    }, [markdownContent, renderedSectionCount]);
 
     // Effect to auto label Definitions, Theorems, Lemmas, only for LaTeX style
     useEffect(() => {
@@ -137,48 +193,7 @@ const Notie: React.FC<NotieProps> = ({
                 }
             });
         }
-    }, [config.theme.blockquoteStyle, markdownContent]);
-
-    // Effect to enable Equation Preview
-    useEffect(() => {
-        if (!contentRef.current) return;
-        const eqnRefs = contentRef.current.querySelectorAll(
-            'a[href^="#pre-eqn-"]',
-        );
-
-        eqnRefs.forEach((ref) => {
-            const equReference = document.createElement("span");
-            const equReferenceComponent = (
-                <EquationReference
-                    children={ref}
-                    equationMapping={equationMapping}
-                    previewEquation={config.previewEquations}
-                />
-            );
-            createRoot(equReference).render(equReferenceComponent);
-            ref.parentNode?.replaceChild(equReference, ref);
-        });
-    }, [config.previewEquations, equationMapping]);
-
-    // Effect to enable Blockquote Preview
-    useEffect(() => {
-        if (!contentRef.current) return;
-        const bqRefs =
-            contentRef.current.querySelectorAll('a[href^="#bqref-"]');
-
-        bqRefs.forEach((ref) => {
-            const bqReference = document.createElement("span");
-            const bqReferenceComponent = (
-                <BlockquoteReference
-                    children={ref}
-                    blockquoteMapping={blockquoteMapping}
-                    previewBlockquotes={config.previewBlockquotes}
-                />
-            );
-            createRoot(bqReference).render(bqReferenceComponent);
-            ref.parentNode?.replaceChild(bqReference, ref);
-        });
-    }, [config.previewBlockquotes, blockquoteMapping]);
+    }, [config.theme.blockquoteStyle, markdownContent, renderedSectionCount]);
 
     return (
         <Pane className={styles["notie-container"]}>
@@ -192,9 +207,10 @@ const Notie: React.FC<NotieProps> = ({
                 {config.showTableOfContents && (
                     <Pane className={styles["vector-column-start"]}>
                         <NoteToc
-                            markdownContent={markdownContent}
+                            tocEntries={tocEntries}
                             activeId={activeId}
                             config={config}
+                            onNavigate={handleTocNavigate}
                         />
                     </Pane>
                 )}
@@ -202,8 +218,15 @@ const Notie: React.FC<NotieProps> = ({
                     <Pane className={styles["blog-content"]} ref={contentRef}>
                         <MarkdownRenderer
                             markdownContent={markdownContent}
+                            markdownSections={markdownSections}
                             config={config}
+                            equationMapping={equationMapping}
+                            blockquoteMapping={blockquoteMapping}
                             customComponents={customComponents}
+                            renderAllToken={renderAllToken}
+                            onRenderedSectionsChange={
+                                handleRenderedSectionsChange
+                            }
                         />
                         <ScrollToTopButton />
                     </Pane>

--- a/src/components/NotieToc.tsx
+++ b/src/components/NotieToc.tsx
@@ -1,83 +1,47 @@
 import { Pane } from "evergreen-ui";
-import rehypeRaw from "rehype-raw";
-import { useEffect, useMemo, useRef } from "react";
-import ReactMarkdown from "react-markdown";
+import React, { useEffect, useRef } from "react";
 import { NotieConfig } from "../config/NotieConfig";
 import styles from "../styles/NotieToc.module.css";
-
-const generateTableOfContents = (
-    markdownContent: string,
-    activeId: string,
-    tocTitle?: string,
-): string => {
-    let res = `# ${tocTitle}\n---\n`;
-    const pattern = /^#+ (.*)$/gm;
-    let match;
-
-    while ((match = pattern.exec(markdownContent)) !== null) {
-        const [fullMatch, title] = match;
-        const level = fullMatch.match(/^#+/)?.[0].length || 0;
-        if (level === 1) continue;
-
-        const cleanedTitle = title.replace(/[*]/g, "").trim();
-        const id = cleanedTitle
-            .replace(/\s+/g, "-")
-            .toLowerCase()
-            .replace(/[+.()'`]/g, "")
-            .replace(/&nbsp;/g, "")
-            .replace(/&/g, "")
-            .replace(/:/g, "");
-
-        const formattedTitle =
-            activeId === id ? `**${cleanedTitle}**` : cleanedTitle;
-
-        res += `${"\t".repeat(level - 2)}- <a id="toc-${id}" href="#${id}">${formattedTitle}</a>\n`;
-    }
-
-    return res;
-};
+import { TocEntry } from "../utils/toc";
 
 const NotieToc = ({
-    markdownContent,
+    tocEntries,
     activeId,
     config,
+    onNavigate,
 }: {
-    markdownContent: string;
+    tocEntries: TocEntry[];
     activeId: string;
     config: NotieConfig;
+    onNavigate?: (
+        id: string,
+        event: React.MouseEvent<HTMLAnchorElement>,
+    ) => void;
 }) => {
-    const tocRef = useRef<HTMLDivElement>(null); // Ref for the TOC container
-
-    const toc = useMemo(
-        () =>
-            generateTableOfContents(markdownContent, activeId, config.tocTitle),
-        [markdownContent, activeId, config.tocTitle],
-    );
+    const tocRef = useRef<HTMLElement>(null);
 
     useEffect(() => {
         const tocContainer = tocRef.current;
-        if (tocContainer) {
-            const activeElement = tocContainer.querySelector(
-                `#toc-${activeId}`,
-            );
-            if (activeElement) {
-                const tocRect = tocContainer.getBoundingClientRect();
-                const activeRect = activeElement.getBoundingClientRect();
-                const offset =
-                    activeRect.top -
-                    tocRect.top -
-                    tocContainer.clientHeight / 2;
+        if (!tocContainer || !activeId) return;
 
-                tocContainer.scrollTo({
-                    top: tocContainer.scrollTop + offset,
-                    behavior: "smooth",
-                });
-            }
-        }
+        const activeElement = document.getElementById(`toc-${activeId}`);
+        if (!activeElement || !tocContainer.contains(activeElement)) return;
+
+        const tocRect = tocContainer.getBoundingClientRect();
+        const activeRect = activeElement.getBoundingClientRect();
+        const offset =
+            activeRect.top - tocRect.top - tocContainer.clientHeight / 2;
+
+        tocContainer.scrollTo({
+            top: tocContainer.scrollTop + offset,
+            behavior: "smooth",
+        });
     }, [activeId]);
 
     return (
         <Pane
+            is="nav"
+            aria-label={config.tocTitle}
             position="sticky"
             top={0}
             overflowY="auto"
@@ -85,7 +49,29 @@ const NotieToc = ({
             className={styles["note-toc"]}
             ref={tocRef}
         >
-            <ReactMarkdown rehypePlugins={[rehypeRaw]}>{toc}</ReactMarkdown>
+            <h1>{config.tocTitle}</h1>
+            <hr />
+            <ul>
+                {tocEntries.map((entry, index) => (
+                    <li
+                        key={`${entry.id}-${entry.level}-${index}`}
+                        style={{ marginLeft: `${entry.level - 2}em` }}
+                    >
+                        <a
+                            id={`toc-${entry.id}`}
+                            href={`#${entry.id}`}
+                            onClick={(event) => onNavigate?.(entry.id, event)}
+                            className={
+                                activeId === entry.id
+                                    ? styles["active"]
+                                    : undefined
+                            }
+                        >
+                            {entry.title}
+                        </a>
+                    </li>
+                ))}
+            </ul>
         </Pane>
     );
 };

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,21 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ArrowUpIcon, Button, Pane } from "evergreen-ui";
 
 const ScrollToTopButton = () => {
     const [isVisible, setIsVisible] = useState(false);
-    const [lastScrollTop, setLastScrollTop] = useState(0);
-
-    const toggleVisibility = () => {
-        const currentScrollTop = window.pageYOffset;
-        const closeToTop = currentScrollTop < 600;
-
-        if (!closeToTop && currentScrollTop < lastScrollTop) {
-            setIsVisible(true);
-        } else {
-            setIsVisible(false);
-        }
-        setLastScrollTop(currentScrollTop);
-    };
+    const lastScrollTopRef = useRef(0);
+    const frameRef = useRef<number | null>(null);
 
     const scrollToTop = () => {
         window.scrollTo({
@@ -25,12 +14,29 @@ const ScrollToTopButton = () => {
     };
 
     useEffect(() => {
-        window.addEventListener("scroll", toggleVisibility);
+        const toggleVisibility = () => {
+            if (frameRef.current !== null) return;
+
+            frameRef.current = window.requestAnimationFrame(() => {
+                const currentScrollTop = window.pageYOffset;
+                const closeToTop = currentScrollTop < 600;
+
+                setIsVisible(
+                    !closeToTop && currentScrollTop < lastScrollTopRef.current,
+                );
+                lastScrollTopRef.current = currentScrollTop;
+                frameRef.current = null;
+            });
+        };
+
+        window.addEventListener("scroll", toggleVisibility, { passive: true });
         return () => {
             window.removeEventListener("scroll", toggleVisibility);
+            if (frameRef.current !== null) {
+                window.cancelAnimationFrame(frameRef.current);
+            }
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [lastScrollTop]);
+    }, []);
 
     return isVisible ? (
         <Pane display="flex" justifyContent="center">

--- a/src/components/TikZ.test.tsx
+++ b/src/components/TikZ.test.tsx
@@ -1,0 +1,53 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import TikZ from "./TikZ";
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((promiseResolve) => {
+        resolve = promiseResolve;
+    });
+
+    return { promise, resolve };
+}
+
+describe("TikZ", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        document.head.innerHTML = "";
+        document.body.innerHTML = "";
+    });
+
+    it("waits for the TikZJax loader before appending text/tikz scripts", async () => {
+        const scriptText = deferred<string>();
+        const fetchMock = vi.fn((url: string) => {
+            if (url.includes("styles.css")) {
+                return Promise.resolve({
+                    ok: true,
+                    text: () => Promise.resolve(".tikz-drawing {}"),
+                });
+            }
+
+            return Promise.resolve({
+                ok: true,
+                text: () => scriptText.promise,
+            });
+        });
+
+        vi.stubGlobal("fetch", fetchMock);
+
+        const { container } = render(
+            <TikZ tikzScript="\\begin{tikzpicture}\\end{tikzpicture}" />,
+        );
+
+        expect(container.querySelector('script[type="text/tikz"]')).toBeNull();
+
+        scriptText.resolve("window.TikzJax = true;");
+
+        await waitFor(() => {
+            expect(
+                container.querySelector('script[type="text/tikz"]'),
+            ).toHaveTextContent("tikzpicture");
+        });
+    });
+});

--- a/src/components/TikZ.tsx
+++ b/src/components/TikZ.tsx
@@ -2,6 +2,47 @@ import { Pane } from "evergreen-ui";
 import { useEffect, useRef } from "react";
 import styles from "../styles/Notie.module.css";
 
+let tikzCssPromise: Promise<void> | null = null;
+let tikzScriptPromise: Promise<void> | null = null;
+
+function loadTikzCss(): Promise<void> {
+    if (!tikzCssPromise) {
+        tikzCssPromise = fetch(
+            "https://raw.githubusercontent.com/artisticat1/obsidian-tikzjax/main/styles.css",
+        )
+            .then((response) => {
+                if (response.ok) return response.text();
+                throw new Error("Failed to load CSS");
+            })
+            .then((cssContent) => {
+                const styleEl = document.createElement("style");
+                styleEl.textContent = cssContent;
+                document.head.appendChild(styleEl);
+            });
+    }
+
+    return tikzCssPromise;
+}
+
+function loadTikzScript(): Promise<void> {
+    if (!tikzScriptPromise) {
+        tikzScriptPromise = fetch(
+            "https://raw.githubusercontent.com/artisticat1/obsidian-tikzjax/main/tikzjax.js",
+        )
+            .then((response) => {
+                if (response.ok) return response.text();
+                throw new Error("Failed to load script");
+            })
+            .then((scriptContent) => {
+                const scriptEl = document.createElement("script");
+                scriptEl.textContent = scriptContent;
+                document.body.appendChild(scriptEl);
+            });
+    }
+
+    return tikzScriptPromise;
+}
+
 function tidyTikzSource(tikzSource: string) {
     // Remove non-breaking space characters, otherwise we get errors
     const remove = /&nbsp;/g;
@@ -18,83 +59,59 @@ function tidyTikzSource(tikzSource: string) {
     return lines.join("\n");
 }
 
+function removeTikzScripts(container: HTMLDivElement | null) {
+    if (!container) return;
+
+    const existingScripts = container.querySelectorAll(
+        'script[type="text/tikz"]',
+    );
+    existingScripts.forEach((script) => script.remove());
+}
+
+function waitForNextFrame(): Promise<void> {
+    if (typeof window === "undefined") return Promise.resolve();
+
+    return new Promise((resolve) => {
+        window.requestAnimationFrame(() => resolve());
+    });
+}
+
 const TikZ = ({ tikzScript }: { tikzScript: string }) => {
     const scriptContainerRef = useRef<HTMLDivElement>(null);
-    const scriptLoaded = useRef(false);
-    const cssLoaded = useRef(false);
 
     useEffect(() => {
-        // Load CSS if not already loaded
-        if (!cssLoaded.current) {
-            fetch(
-                "https://raw.githubusercontent.com/artisticat1/obsidian-tikzjax/main/styles.css",
-            )
-                .then((response) => {
-                    if (response.ok) return response.text();
-                    throw new Error("Failed to load CSS");
-                })
-                .then((cssContent) => {
-                    const styleEl = document.createElement("style");
-                    styleEl.textContent = cssContent;
-                    document.head.appendChild(styleEl);
-                    cssLoaded.current = true;
-                })
-                .catch((error) => console.error("Failed to load CSS", error));
-        }
+        const container = scriptContainerRef.current;
+        let isCancelled = false;
 
-        // Load script if not already loaded
-        if (!scriptLoaded.current) {
-            fetch(
-                "https://raw.githubusercontent.com/artisticat1/obsidian-tikzjax/main/tikzjax.js",
-            )
-                .then((response) => response.text())
-                .then((scriptContent) => {
-                    const scriptEl = document.createElement("script");
-                    scriptEl.textContent = scriptContent;
-                    document.body.appendChild(scriptEl);
-                    scriptLoaded.current = true;
-                })
-                .catch((error) =>
-                    console.error("Failed to load script", error),
-                );
-        }
-
-        // Cleanup on component unmount
-        return () => {
-            if (scriptContainerRef.current) {
-                // Remove any existing TikZ scripts when component unmounts
-                const existingScripts =
-                    // eslint-disable-next-line react-hooks/exhaustive-deps
-                    scriptContainerRef.current.querySelectorAll(
-                        'script[type="text/tikz"]',
-                    );
-                existingScripts.forEach((script) => script.remove());
+        async function renderTikz() {
+            try {
+                await Promise.all([loadTikzCss(), loadTikzScript()]);
+                await waitForNextFrame();
+            } catch (error) {
+                console.error("Failed to load TikZJax", error);
+                return;
             }
-        };
-    }, []);
 
-    useEffect(() => {
-        function loadTikZJax() {
+            if (isCancelled || !container) return;
+
             const scriptEl = document.createElement("script");
             scriptEl.type = "text/tikz";
             scriptEl.async = true;
             scriptEl.textContent = tidyTikzSource(tikzScript);
-
             scriptEl.setAttribute("data-show-console", "true");
 
-            if (scriptContainerRef.current) {
-                // Remove any previous TikZ scripts before adding a new one
-                const existingScripts =
-                    scriptContainerRef.current.querySelectorAll(
-                        'script[type="text/tikz"]',
-                    );
-                existingScripts.forEach((script) => script.remove());
-
-                scriptContainerRef.current.appendChild(scriptEl);
-            }
+            // TikZJax registers a MutationObserver after its loader runs, so
+            // append only after the loader promise resolves.
+            removeTikzScripts(container);
+            container.appendChild(scriptEl);
         }
 
-        loadTikZJax();
+        renderTikz();
+
+        return () => {
+            isCancelled = true;
+            removeTikzScripts(container);
+        };
     }, [tikzScript]);
 
     return (

--- a/src/dev/App.tsx
+++ b/src/dev/App.tsx
@@ -2,11 +2,18 @@ import { useEffect, useState } from "react";
 import Notie from "../components/Notie";
 import { Pane, majorScale, Select } from "evergreen-ui";
 import { NotieThemes } from "../config/NotieConfig";
+import initialMarkdown from "./test.md?raw";
 
-const modules = import.meta.glob("./test.md", {
-    query: "?raw",
-    import: "default",
-});
+const markdownListeners = new Set<(markdown: string) => void>();
+let currentMarkdown = initialMarkdown;
+
+if (import.meta.hot) {
+    import.meta.hot.accept("./test.md?raw", (module) => {
+        if (!module) return;
+        currentMarkdown = module.default;
+        markdownListeners.forEach((listener) => listener(currentMarkdown));
+    });
+}
 
 const THEMES: NotieThemes[] = [
     "default",
@@ -23,20 +30,16 @@ const BACKGROUND: Record<NotieThemes, string> = {
 };
 
 const App = () => {
-    const [markdownContent, setMarkdownContent] = useState<string>("");
+    const [markdownContent, setMarkdownContent] =
+        useState<string>(currentMarkdown);
     const [theme, setTheme] = useState<NotieThemes>("default");
 
     useEffect(() => {
-        const fetchNote = async () => {
-            for (const path in modules) {
-                const markdown = await modules[path]();
-                const rawMDString = markdown as string;
-                setMarkdownContent(rawMDString);
-                break;
-            }
-        };
+        markdownListeners.add(setMarkdownContent);
 
-        fetchNote();
+        return () => {
+            markdownListeners.delete(setMarkdownContent);
+        };
     }, []);
 
     return (

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,34 @@
+import "@testing-library/jest-dom/vitest";
+
+class MockIntersectionObserver implements IntersectionObserver {
+    readonly root = null;
+    readonly rootMargin = "";
+    readonly thresholds = [];
+
+    disconnect() {}
+    observe() {}
+    takeRecords(): IntersectionObserverEntry[] {
+        return [];
+    }
+    unobserve() {}
+}
+
+Object.defineProperty(window, "IntersectionObserver", {
+    writable: true,
+    value: MockIntersectionObserver,
+});
+
+Object.defineProperty(globalThis, "IntersectionObserver", {
+    writable: true,
+    value: MockIntersectionObserver,
+});
+
+Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    writable: true,
+    value: () => {},
+});
+
+Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+    writable: true,
+    value: () => {},
+});

--- a/src/utils/MarkdownProcessor.test.ts
+++ b/src/utils/MarkdownProcessor.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import { MarkdownProcessor } from "./MarkdownProcessor";
+import { FullNotieConfig } from "../config/NotieConfig";
+
+const config: FullNotieConfig = {
+    showTableOfContents: true,
+    previewEquations: true,
+    previewBlockquotes: true,
+    tocTitle: "Contents",
+    fontSize: "1rem",
+    theme: {
+        appearance: "light",
+        backgroundColor: "#fff",
+        fontFamily: "",
+        customFontUrl: "",
+        titleColor: "#000",
+        textColor: "#000",
+        linkColor: "#36f",
+        linkHoverColor: "#0000cf",
+        linkUnderline: false,
+        tocFontFamily: "",
+        tocCustomFontUrl: "",
+        tocColor: "#000",
+        tocHoverColor: "#777",
+        tocUnderline: false,
+        codeColor: "#000",
+        codeBackgroundColor: "#fafafa",
+        codeHeaderColor: "rgba(175, 184, 193, 0.2)",
+        codeFontSize: "medium",
+        codeCopyButtonHoverColor: "#F4F5F9",
+        staticCodeTheme: "github-light",
+        liveCodeTheme: "github-light",
+        collapseSectionColor: "#f0f0f0",
+        katexSize: "1.21rem",
+        tableBorderColor: "#ddd",
+        tableBackgroundColor: "#f2f2f2",
+        captionColor: "#555",
+        subtitleColor: "#969696",
+        tikZstyle: "default",
+        blockquoteStyle: "latex",
+        numberedHeading: true,
+        tocMarker: false,
+    },
+};
+
+describe("MarkdownProcessor", () => {
+    it("preserves equation and blockquote mappings while numbering headings", () => {
+        const markdown = `# Title
+
+## Section One
+
+$$
+\\begin{equation} \\label{eq:first}
+x = 1
+\\end{equation}
+$$
+
+<blockquote class="definition" id="def:first">
+Definition body.
+</blockquote>
+
+## Section Two
+
+See $\\eqref{eq:first}$ and [definition](#bqref-def:first).
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.markdownContent).toContain(
+            "## 1&nbsp;&nbsp;&nbsp;Section One",
+        );
+        expect(result.markdownContent).toContain(
+            "## 2&nbsp;&nbsp;&nbsp;Section Two",
+        );
+        expect(result.equationMapping["eq:first"]).toEqual({
+            equationNumber: "1.1",
+            equationString: "\n \nx = 1\n\n",
+        });
+        expect(result.blockquoteMapping["def:first"]).toEqual({
+            blockquoteNumber: "1.1",
+            blockquoteType: "definition",
+            blockquoteContent: "Definition body.",
+        });
+    });
+
+    it("does not scan labels inside fenced code blocks", () => {
+        const errorSpy = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+        const markdown = `# Title
+
+## Section
+
+$$
+\\begin{equation} \\label{eq:real}
+x = 1
+\\end{equation}
+$$
+
+\`\`\`tex
+$$
+\\begin{equation} \\label{eq:real}
+not real
+\\end{equation}
+$$
+<blockquote class="definition" id="def:not-real">Nope</blockquote>
+\`\`\`
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(Object.keys(result.equationMapping)).toEqual(["eq:real"]);
+        expect(result.blockquoteMapping).toEqual({});
+        expect(errorSpy).not.toHaveBeenCalled();
+        errorSpy.mockRestore();
+    });
+});

--- a/src/utils/MarkdownProcessor.ts
+++ b/src/utils/MarkdownProcessor.ts
@@ -14,6 +14,7 @@ export class MarkdownProcessor {
 
     public process(): {
         markdownContent: string;
+        markdownSections: string[];
         equationMapping: EquationMapping;
         blockquoteMapping: BlockquoteMapping;
     } {
@@ -24,11 +25,11 @@ export class MarkdownProcessor {
         });
 
         if (this.config.theme?.numberedHeading) {
-            const processedMarkdown = this.addHeadingNumbers(
-                processedSections.join(""),
-            );
+            const numberedSections =
+                this.addHeadingNumbersToSections(processedSections);
             return {
-                markdownContent: processedMarkdown,
+                markdownContent: numberedSections.join(""),
+                markdownSections: numberedSections,
                 equationMapping: this.equationMapping,
                 blockquoteMapping: this.blockquoteMapping,
             };
@@ -36,26 +37,29 @@ export class MarkdownProcessor {
 
         return {
             markdownContent: processedSections.join(""),
+            markdownSections: processedSections,
             equationMapping: this.equationMapping,
             blockquoteMapping: this.blockquoteMapping,
         };
     }
 
-    private addHeadingNumbers(markdownString: string): string {
+    private addHeadingNumbersToSections(sections: string[]): string[] {
         const headingRegex = /^(#{2,6}) (.*)$/gm;
         const counters = [0, 0, 0, 0, 0];
 
-        return markdownString.replace(headingRegex, (_match, hashes, title) => {
-            const level = hashes.length - 2;
-            counters[level]++;
+        return sections.map((section) =>
+            section.replace(headingRegex, (_match, hashes, title) => {
+                const level = hashes.length - 2;
+                counters[level]++;
 
-            for (let i = level + 1; i < counters.length; i++) {
-                counters[i] = 0;
-            }
+                for (let i = level + 1; i < counters.length; i++) {
+                    counters[i] = 0;
+                }
 
-            const numbering = counters.slice(0, level + 1).join(".");
-            return `${hashes} ${numbering}&nbsp;&nbsp;&nbsp;${title}`;
-        });
+                const numbering = counters.slice(0, level + 1).join(".");
+                return `${hashes} ${numbering}&nbsp;&nbsp;&nbsp;${title}`;
+            }),
+        );
     }
 
     private splitIntoSections(): string[] {

--- a/src/utils/katexOptions.ts
+++ b/src/utils/katexOptions.ts
@@ -1,0 +1,10 @@
+export const katexOptions = {
+    macros: {
+        "\\eqref": "\\href{\\#pre-eqn-eqref:#1}{}",
+        "\\ref": "\\href{\\#pre-eqn-ref:#1}{}",
+        "\\label": "\\htmlId{#1}{}",
+    },
+    strict: false,
+    trust: (context: { command: string }) =>
+        ["\\htmlId", "\\href"].includes(context.command),
+};

--- a/src/utils/toc.ts
+++ b/src/utils/toc.ts
@@ -1,0 +1,36 @@
+export interface TocEntry {
+    id: string;
+    level: number;
+    title: string;
+}
+
+export function markdownHeadingToId(title: string): string {
+    return title
+        .replace(/\s+/g, "-")
+        .toLowerCase()
+        .replace(/[+.()'`]/g, "")
+        .replace(/&nbsp;/g, "")
+        .replace(/&/g, "")
+        .replace(/:/g, "");
+}
+
+export function extractTableOfContents(markdownContent: string): TocEntry[] {
+    const entries: TocEntry[] = [];
+    const pattern = /^#+ (.*)$/gm;
+    let match;
+
+    while ((match = pattern.exec(markdownContent)) !== null) {
+        const [fullMatch, title] = match;
+        const level = fullMatch.match(/^#+/)?.[0].length || 0;
+        if (level === 1) continue;
+
+        const cleanedTitle = title.replace(/[*]/g, "").trim();
+        entries.push({
+            id: markdownHeadingToId(cleanedTitle),
+            level,
+            title: cleanedTitle.replace(/&nbsp;/g, "\u00a0"),
+        });
+    }
+
+    return entries;
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,10 +7,9 @@ export interface BlockquoteMapping {
 }
 
 export function extractBlockquoteInfo(
-    children: Element,
+    href: string | null | undefined,
     blockquoteMapping: BlockquoteMapping,
 ) {
-    const href = children.getAttribute("href");
     const label = href?.split("#bqref-").pop();
     if (!label) throw new Error("No blockquote label found");
 
@@ -37,18 +36,46 @@ export interface EquationMapping {
     };
 }
 
-// Used in EquationReference.tsx
-export function extractEquationInfo(
-    children: Element,
-    equationMapping: EquationMapping,
-) {
-    const href = children.getAttribute("href");
-    const label = href?.split("#pre-eqn-").pop();
-    if (!label) {
-        throw new Error("No equation label found");
+function parseEquationReferenceHref(href: string | null | undefined) {
+    const rawLabel = href?.split("#pre-eqn-").pop();
+    if (!rawLabel) return null;
+
+    if (rawLabel.startsWith("eqref:")) {
+        return {
+            label: rawLabel.slice("eqref:".length),
+            parenthesesRemoved: true,
+        };
     }
 
-    const parenthesesRemoved = children.textContent?.includes("(") ?? false;
+    if (rawLabel.startsWith("ref:")) {
+        return {
+            label: rawLabel.slice("ref:".length),
+            parenthesesRemoved: false,
+        };
+    }
+
+    return {
+        label: rawLabel,
+        parenthesesRemoved: undefined,
+    };
+}
+
+// Used in EquationReference.tsx
+export function extractEquationInfo(
+    href: string | null | undefined,
+    textContent: string | null | undefined,
+    equationMapping: EquationMapping,
+) {
+    const parsedReference = parseEquationReferenceHref(href);
+    if (!parsedReference) {
+        throw new Error("No equation label found");
+    }
+    const { label } = parsedReference;
+
+    const parenthesesRemoved =
+        parsedReference.parenthesesRemoved ??
+        textContent?.includes("(") ??
+        false;
 
     if (!(label in equationMapping)) {
         console.error(
@@ -58,7 +85,7 @@ export function extractEquationInfo(
         return {
             equationNumber: `Error: reference ${label} not labeled`,
             equationString: "error",
-            parenthesesRemoved: false,
+            parenthesesRemoved,
         };
     }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,11 @@ import dts from "vite-plugin-dts";
 import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 
 export default defineConfig({
+    test: {
+        environment: "jsdom",
+        setupFiles: ["src/test/setup.ts"],
+        globals: true,
+    },
     build: {
         lib: {
             entry: path.resolve(__dirname, "src/index.ts"),
@@ -23,6 +28,17 @@ export default defineConfig({
         sourcemap: true,
         emptyOutDir: true,
     },
-    plugins: [react(), dts(), cssInjectedByJsPlugin()],
+    plugins: [
+        react(),
+        dts({
+            exclude: [
+                "src/**/*.test.ts",
+                "src/**/*.test.tsx",
+                "src/dev/**",
+                "src/test/**",
+            ],
+        }),
+        cssInjectedByJsPlugin(),
+    ],
     assetsInclude: ["**/*.md"],
 });


### PR DESCRIPTION
## Summary
- progressively render markdown sections and lazy-load expensive blocks so large notes become interactive sooner
- replace post-render DOM reference rewriting with ReactMarkdown anchor components for equation and blockquote references
- fix underscore equation labels, equation refs inside algorithm/blockquote hover cards, and TikZ/Desmos loader ordering
- add TOC extraction, synthetic benchmarking, and regression tests for renderer, processor, and TikZ behavior

## Verification
- npm run format
- npm run lint
- npm test
- npm run benchmark
- npm run build
- git diff --check
- npm pack --dry-run