### PR TITLE
fix: copy-button timer cleanup and clipboard error handling (NOTIE-004)

### DIFF
--- a/src/components/CodeHeader.test.tsx
+++ b/src/components/CodeHeader.test.tsx
@@ -1,0 +1,132 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CodeHeader from "./CodeHeader";
+
+const originalClipboard = navigator.clipboard;
+
+function stubClipboard(writeText: ReturnType<typeof vi.fn>) {
+    Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        writable: true,
+        value: { writeText },
+    });
+}
+
+function restoreClipboard() {
+    Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        writable: true,
+        value: originalClipboard,
+    });
+}
+
+describe("CodeHeader", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+        restoreClipboard();
+        vi.restoreAllMocks();
+    });
+
+    it("copies the code, shows 'Copied!', and reverts after 2000ms", async () => {
+        const writeText = vi.fn(() => Promise.resolve());
+        stubClipboard(writeText);
+
+        render(<CodeHeader language="python" code="print('hello')" />);
+
+        fireEvent.click(screen.getByRole("button", { name: /copy code/i }));
+        // Flush the clipboard promise's .then callback.
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(writeText).toHaveBeenCalledWith("print('hello')");
+        expect(screen.getByText("Copied!")).toBeInTheDocument();
+
+        act(() => {
+            vi.advanceTimersByTime(2000);
+        });
+
+        expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
+        expect(screen.getByText("Copy Code")).toBeInTheDocument();
+    });
+
+    it("does not show 'Copied!' when the clipboard write rejects", async () => {
+        const writeText = vi.fn(() => Promise.reject(new Error("denied")));
+        stubClipboard(writeText);
+
+        const unhandled = vi.fn();
+        process.on("unhandledRejection", unhandled);
+
+        try {
+            render(<CodeHeader language="python" code="print('hello')" />);
+
+            fireEvent.click(screen.getByRole("button", { name: /copy code/i }));
+            await act(async () => {
+                await Promise.resolve();
+                await Promise.resolve();
+            });
+
+            expect(writeText).toHaveBeenCalledWith("print('hello')");
+            expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
+            expect(screen.getByText("Copy Code")).toBeInTheDocument();
+            expect(unhandled).not.toHaveBeenCalled();
+        } finally {
+            process.off("unhandledRejection", unhandled);
+        }
+    });
+
+    it("does nothing when navigator.clipboard is unavailable", () => {
+        Object.defineProperty(navigator, "clipboard", {
+            configurable: true,
+            writable: true,
+            value: undefined,
+        });
+
+        render(<CodeHeader language="python" code="print('hello')" />);
+
+        expect(() =>
+            fireEvent.click(screen.getByRole("button", { name: /copy code/i })),
+        ).not.toThrow();
+        expect(screen.getByText("Copy Code")).toBeInTheDocument();
+    });
+
+    it("cleans up the timer on unmount without state-update warnings", async () => {
+        const writeText = vi.fn(() => Promise.resolve());
+        stubClipboard(writeText);
+
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+
+        const { unmount } = render(
+            <CodeHeader language="python" code="print('hello')" />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: /copy code/i }));
+        await act(async () => {
+            await Promise.resolve();
+        });
+        expect(screen.getByText("Copied!")).toBeInTheDocument();
+
+        unmount();
+
+        act(() => {
+            vi.advanceTimersByTime(2000);
+        });
+        expect(vi.getTimerCount()).toBe(0);
+
+        const warnings = consoleError.mock.calls
+            .map((call) => String(call[0]))
+            .filter(
+                (message) =>
+                    message.includes("act(") ||
+                    message.includes("unmounted component"),
+            );
+        expect(warnings).toEqual([]);
+    });
+});

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -1,28 +1,53 @@
 import { Pane, Button, ClipboardIcon, TickCircleIcon } from "evergreen-ui";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styles from "../styles/Notie.module.css";
 
 const CodeHeader = ({ language, code }: { language: string; code: string }) => {
     const [isCopied, setIsCopied] = useState(false);
-    const [timer, setTimer] = useState<NodeJS.Timeout | null>(null);
+    const timerRef = useRef<NodeJS.Timeout | null>(null);
+    const isMountedRef = useRef(true);
+
+    useEffect(() => {
+        isMountedRef.current = true;
+        return () => {
+            isMountedRef.current = false;
+            if (timerRef.current) {
+                clearTimeout(timerRef.current);
+                timerRef.current = null;
+            }
+        };
+    }, []);
 
     const copyToClipboard = () => {
-        navigator.clipboard.writeText(code).then(() => {
-            setIsCopied(true);
-            if (timer) {
-                clearTimeout(timer);
-            }
-            const newTimer = setTimeout(() => {
-                setIsCopied(false);
-            }, 2000);
-            setTimer(newTimer);
-        });
+        if (!navigator.clipboard?.writeText) {
+            return;
+        }
+        navigator.clipboard
+            .writeText(code)
+            .then(() => {
+                if (!isMountedRef.current) {
+                    return;
+                }
+                setIsCopied(true);
+                if (timerRef.current) {
+                    clearTimeout(timerRef.current);
+                }
+                timerRef.current = setTimeout(() => {
+                    setIsCopied(false);
+                    timerRef.current = null;
+                }, 2000);
+            })
+            .catch(() => {
+                // Clipboard write failed (e.g. permission denied or insecure
+                // origin); leave the button in its default state.
+            });
     };
 
     const resetCopy = () => {
         setIsCopied(false);
-        if (timer) {
-            clearTimeout(timer);
+        if (timerRef.current) {
+            clearTimeout(timerRef.current);
+            timerRef.current = null;
         }
     };
 


### PR DESCRIPTION
## Problem

`src/components/CodeHeader.tsx` had two bugs in the copy button:

1. The 2s reset `setTimeout` was stored in React state and never cleared on unmount, causing `setIsCopied(false)` to fire after unmount (setState-after-unmount).
2. `navigator.clipboard.writeText(code)` had no `.catch`, and `navigator.clipboard` can be `undefined` on insecure (non-HTTPS) origins — clicking the button there threw, and any write rejection produced an unhandled promise rejection.

## Solution

- Moved the timer into a `useRef` and added a `useEffect` cleanup that clears it (and marks the component unmounted) on unmount; the resolved-clipboard callback bails out if the component is gone.
- Guarded `navigator.clipboard?.writeText` existence before use and added a `.catch` on the write; on failure the button safely stays in its default "Copy Code" state and never shows "Copied!".
- Visual behavior is otherwise unchanged (same icons, labels, 2s revert, click-to-reset).

## Tests

New `src/components/CodeHeader.test.tsx` (fake timers + stubbed `navigator.clipboard`, restored after each test):

- click → `writeText` called with the code, label shows "Copied!", reverts to "Copy Code" after 2000ms
- clipboard write rejects → no "Copied!" state, no unhandled rejection
- `navigator.clipboard` undefined → click is a safe no-op
- unmount within 2s of click → timer cleared (`vi.getTimerCount() === 0`), no act()/state-update-on-unmounted warnings

Checks: `npm test` (14 passed), `npm run lint`, `npm run build` — all pass.

## Risk

Low. Single component; only failure-path and lifecycle behavior changed. One edge-case behavior change: on clipboard failure the button no longer (incorrectly) shows "Copied!".

🤖 Generated with [Claude Code](https://claude.com/claude-code)