### PR TITLE
fix(demo): combobox null guard, dead nav branches, 404 route, sort comparator, typed PACKAGE_VERSION (NOTIE-023)

### DIFF
--- a/demo-app/src/App.tsx
+++ b/demo-app/src/App.tsx
@@ -4,6 +4,7 @@ import NavBar from "./components/NavBar";
 import { Route, Routes } from "react-router-dom";
 import Examples from "./pages/Examples";
 import ExamplePage from "./pages/ExamplePage";
+import NotFound from "./pages/NotFound";
 import { useEffect, useState } from "react";
 import { useTheme } from "./context/useTheme";
 import MyChart from "./components/MyChart";
@@ -118,6 +119,7 @@ const App = () => {
                             path="/examples/:noteId"
                             element={<ExamplePage />}
                         />
+                        <Route path="*" element={<NotFound />} />
                     </Routes>
                 </Pane>
             </Pane>

--- a/demo-app/src/components/NavBar.tsx
+++ b/demo-app/src/components/NavBar.tsx
@@ -72,7 +72,11 @@ const NavBar = () => {
                                 { label: "Starlit Eclipse Light" },
                             ]}
                             itemToString={(item) => (item ? item.label : "")}
-                            onChange={(selected) => setTheme(selected.label)}
+                            onChange={(selected) => {
+                                if (selected?.label) {
+                                    setTheme(selected.label);
+                                }
+                            }}
                         />
                     </Pane>
                     {isMobile ? (

--- a/demo-app/src/components/NavButton.tsx
+++ b/demo-app/src/components/NavButton.tsx
@@ -16,19 +16,8 @@ const NavMobileMenu = ({ tabs }: { tabs: string[] }) => {
     const navigate = useNavigate();
 
     const handleSelect = (tab: string) => {
-        let path: string;
-
-        switch (tab) {
-            case "Home":
-                path = "/";
-                break;
-            case "Relevant Coursework":
-                path = "/coursework";
-                break;
-            default:
-                path = `/${tab.toLowerCase().replace(/\s+/g, "")}`;
-                break;
-        }
+        const path =
+            tab === "Home" ? "/" : `/${tab.toLowerCase().replace(/\s+/g, "")}`;
 
         navigate(path);
     };
@@ -77,19 +66,10 @@ const NavButton = ({
     };
 
     const handleClick = () => {
-        let path: string;
-
-        switch (label) {
-            case "Home":
-                path = "/";
-                break;
-            case "Relevant Coursework":
-                path = "/coursework";
-                break;
-            default:
-                path = `/${label.toLowerCase().replace(/\s+/g, "")}`;
-                break;
-        }
+        const path =
+            label === "Home"
+                ? "/"
+                : `/${label.toLowerCase().replace(/\s+/g, "")}`;
 
         navigate(path);
     };

--- a/demo-app/src/pages/Examples.tsx
+++ b/demo-app/src/pages/Examples.tsx
@@ -55,7 +55,8 @@ const Examples = () => {
                     date: date,
                 });
             }
-            notesData.sort((b, a) => sortNotesByDate(a.date, b.date));
+            // sortNotesByDate compares ascending; reverse args for newest-first order.
+            notesData.sort((a, b) => sortNotesByDate(b.date, a.date));
             setNotesMetaData(notesData);
             setLoading(false);
         }

--- a/demo-app/src/pages/NotFound.tsx
+++ b/demo-app/src/pages/NotFound.tsx
@@ -1,0 +1,37 @@
+import { Heading, majorScale, Pane, Paragraph } from "evergreen-ui";
+import { Link } from "react-router-dom";
+import { useTheme } from "../context/useTheme";
+
+const NotFound = () => {
+    const { theme } = useTheme();
+    const darkMode = theme === "default dark" || theme === "Starlit Eclipse";
+
+    return (
+        <Pane
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            padding={majorScale(4)}
+            style={{ margin: "0 auto" }}
+        >
+            <Heading
+                size={800}
+                marginBottom={majorScale(2)}
+                color={darkMode ? "white" : "default"}
+            >
+                Page Not Found
+            </Heading>
+            <Paragraph color={darkMode ? "white" : "default"}>
+                The page you are looking for does not exist.{" "}
+                <Link
+                    to="/"
+                    style={{ color: darkMode ? "white" : "#3366FF" }}
+                >
+                    Go back home
+                </Link>
+            </Paragraph>
+        </Pane>
+    );
+};
+
+export default NotFound;

--- a/demo-app/src/vite-env.d.ts
+++ b/demo-app/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    /** Injected at build time via `define` in demo-app/vite.config.ts. */
+    readonly PACKAGE_VERSION: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Problem

Several small defects in the demo app (`demo-app/src`):

1. **NavBar theme Combobox crash** — evergreen-ui's `Combobox` calls `onChange(null)` when the field is cleared; `setTheme(selected.label)` then threw `TypeError: Cannot read properties of null`.
2. **Dead navigation branches** — `NavButton.tsx` had `"Relevant Coursework"` switch cases (in both `NavMobileMenu` and `NavButton`) pointing at `/coursework`, a tab that is not in `TABS` and a route that does not exist.
3. **Blank page on bad URLs** — the router had no catch-all, so any unknown path rendered an empty content area.
4. **Confusing sort comparator** — `Examples.tsx` used `notesData.sort((b, a) => sortNotesByDate(a.date, b.date))`, with parameters double-swapped, obscuring the intended order.
5. **Untyped `import.meta.env.PACKAGE_VERSION`** — read in `NavBar.tsx` and injected via `define` in `demo-app/vite.config.ts`, but not declared, so it typed as `any`.

## Solution

- `NavBar.tsx`: guard the Combobox handler — `if (selected?.label) setTheme(selected.label)`.
- `NavButton.tsx`: removed both dead `"Relevant Coursework"` branches and simplified to a ternary. Remaining tabs map identically: Home → `/`, Examples → `/examples`, Tutorial → `/tutorial`, Contribute → `/contribute`.
- `App.tsx` + new `pages/NotFound.tsx`: added `<Route path="*" element={<NotFound />} />` rendering a theme-aware "Page Not Found" message with a link home.
- `Examples.tsx`: normalized to `notesData.sort((a, b) => sortNotesByDate(b.date, a.date))` with a comment. `sortNotesByDate(x, y)` returns `x - y` (ascending); the original double-swap produced **descending (newest-first)** order, and the normalized comparator produces the exact same descending order — visible ordering is unchanged.
- `vite-env.d.ts`: added `ImportMetaEnv` / `ImportMeta` augmentation declaring `readonly PACKAGE_VERSION: string`.

## Tests

- `demo-app`: `npm install && npm run build` (tsc -b + vite build) — pass; `npm run lint` — clean (`--max-warnings 0`).
- Root: `npm install && npm test` (10 tests, 3 files, all pass), `npm run lint` — clean, `npm run build` — pass.

## Risk

Low. Demo-app-only changes; no library (`src/`) code touched. The sort comparator is algebraically identical to the previous one, and nav paths for all existing tabs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)