### PR TITLE
ci+docs: fix publish workflow loop/ordering/breaking-change detection; add security and config docs (NOTIE-022)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,19 +8,22 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Skip runs triggered by this workflow's own version bump commits to
+    # avoid an infinite re-trigger/auto-republish loop.
+    if: "${{ !startsWith(github.event.head_commit.message, 'ci: bump version') }}"
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Configure npm for authentication
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
@@ -30,14 +33,16 @@ jobs:
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          FIRST_LINE=$(echo "$COMMIT_MSG" | head -1)
-          if [[ "$FIRST_LINE" =~ ^fix ]]; then
-            echo "bump=patch" >> $GITHUB_ENV
-          elif [[ "$FIRST_LINE" =~ ^feat ]]; then
-            echo "bump=minor" >> $GITHUB_ENV
-          elif [[ "$FIRST_LINE" =~ BREAKING[[:space:]]CHANGE ]]; then
+          # BREAKING CHANGE can appear anywhere in the commit message
+          # (subject, body, or footer), so check the full message first.
+          if [[ "$COMMIT_MSG" =~ BREAKING[[:space:]]CHANGE ]]; then
             echo "bump=major" >> $GITHUB_ENV
+          elif [[ "$COMMIT_MSG" =~ ^feat ]]; then
+            echo "bump=minor" >> $GITHUB_ENV
+          elif [[ "$COMMIT_MSG" =~ ^fix ]]; then
+            echo "bump=patch" >> $GITHUB_ENV
           else
+            # Default: any other commit type gets a patch bump.
             echo "bump=patch" >> $GITHUB_ENV
           fi
 
@@ -53,11 +58,9 @@ jobs:
       - name: Build the package
         run: npm run build
 
-      - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+      # Commit and push the version bump BEFORE publishing, so a failed push
+      # cannot leave npm ahead of git. If the push fails, the job fails here
+      # and nothing is published.
       - name: Push version bump
         run: |
           git config user.name "GitHub Actions"
@@ -67,3 +70,8 @@ jobs:
           git push origin HEAD:main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ Then, import the `Notie` component in your React application:
 ```tsx
 import { Notie } from "notie-markdown";
 
-const Example = () => (
-  <Notie markdown="# Hello World\nThis is a Markdown content." />
-);
+const markdown = `# Hello World
+
+This is a Markdown content.`;
+
+const Example = () => <Notie markdown={markdown} />;
 ```
 
 The `Notie` component is used to render Markdown content. It accepts the following props:
@@ -52,6 +54,82 @@ Check out the [tutorial](https://notie-markdown.vercel.app/tutorial) for more de
   - **Automatic Equation Numbering**: Automatically number equations and refer to them in your notes.
 - **Blockquote References**: Label definitions, theorems, lemmas, algorithms, and problems with an `id`, then reference them anywhere in the document with hover-preview tooltips.
 - **Customizable Themes**: Customize the appearance of your notes with different themes.
+
+## Security
+
+Please keep the following in mind when using **notie**:
+
+- **Raw HTML is rendered by design.** notie uses [rehype-raw](https://github.com/rehypejs/rehype-raw) so that HTML embedded in your Markdown (e.g. `<img>`, `<div class="caption">`) renders as-is. This means Markdown is treated as trusted input — do **not** feed untrusted, user-supplied Markdown to the `Notie` component without sanitizing it first, as it can inject arbitrary HTML (including scripts and event handlers) into your page.
+- **`execute-` code blocks send code to a remote execution endpoint.** Live-executable code blocks (e.g. ` ```execute-python `) submit the code to the code execution endpoint over the network when the user clicks Run. The endpoint can be overridden via `config.codeRunnerUrl`. Be mindful of what code is sent, and point the endpoint at infrastructure you control if you have privacy or availability requirements.
+- **`tikz` blocks load a third-party engine.** TikZ diagrams are rendered by the [TikZJax](https://github.com/artisticat1/obsidian-tikzjax) engine, whose script and stylesheet are fetched at runtime from a pinned third-party URL and executed in the page.
+- **`desmos` blocks load the Desmos API script.** Graphs are rendered by loading the [Desmos](https://www.desmos.com/) calculator API script from Desmos servers at runtime.
+
+## Configuration reference
+
+The `config` prop accepts a `NotieConfig` object. All fields are optional; unspecified fields fall back to the selected theme's defaults.
+
+| Option               | Type      | Description                                                          |
+| -------------------- | --------- | -------------------------------------------------------------------- |
+| `showTableOfContents`| `boolean` | Show or hide the table of contents sidebar.                          |
+| `tocTitle`           | `string`  | Title displayed above the table of contents.                         |
+| `previewEquations`   | `boolean` | Show a hover preview when referencing numbered equations.            |
+| `previewBlockquotes` | `boolean` | Show a hover preview when referencing labeled blockquotes.           |
+| `fontSize`           | `string`  | Base font size for the rendered notes (any CSS `font-size` value).   |
+| `theme`              | `Theme`   | Fine-grained theme overrides (see below).                            |
+
+### `Theme` options
+
+| Option                     | Type                       | Description                                                       |
+| -------------------------- | -------------------------- | ----------------------------------------------------------------- |
+| `appearance`               | `"light" \| "dark"`        | Base appearance the theme builds on.                              |
+| `backgroundColor`          | CSS color                  | Page background color.                                            |
+| `fontFamily`               | CSS font-family            | Font family for note text.                                        |
+| `customFontUrl`            | `string`                   | URL of a stylesheet providing the custom font.                    |
+| `titleColor`               | CSS color                  | Color of the note title.                                          |
+| `textColor`                | CSS color                  | Color of body text.                                               |
+| `linkColor`                | CSS color                  | Link color.                                                       |
+| `linkHoverColor`           | CSS color                  | Link color on hover.                                              |
+| `linkUnderline`            | `boolean`                  | Underline links.                                                  |
+| `tocFontFamily`            | CSS font-family            | Font family for the table of contents.                            |
+| `tocCustomFontUrl`         | `string`                   | URL of a stylesheet providing the TOC font.                       |
+| `tocColor`                 | CSS color                  | TOC link color.                                                   |
+| `tocHoverColor`            | CSS color                  | TOC link color on hover.                                          |
+| `tocUnderline`             | `boolean`                  | Underline TOC links.                                              |
+| `codeColor`                | CSS color                  | Inline code text color.                                           |
+| `codeBackgroundColor`      | CSS color                  | Inline code background color.                                     |
+| `codeHeaderColor`          | CSS color                  | Code block header background color.                               |
+| `codeFontSize`             | CSS font-size              | Code font size.                                                   |
+| `codeCopyButtonHoverColor` | CSS color                  | Copy button hover color in code blocks.                           |
+| `staticCodeTheme`          | Shiki theme name           | Syntax highlighting theme for static code blocks.                 |
+| `liveCodeTheme`            | Shiki theme name           | Syntax highlighting theme for live (editable) code blocks.        |
+| `collapseSectionColor`     | CSS color                  | Color of the collapsible section controls.                        |
+| `katexSize`                | CSS font-size              | Font size for KaTeX math.                                         |
+| `tableBorderColor`         | CSS color                  | Table border color.                                               |
+| `tableBackgroundColor`     | CSS color                  | Table background color.                                           |
+| `captionColor`             | CSS color                  | Caption text color.                                               |
+| `subtitleColor`            | CSS color                  | Subtitle text color.                                              |
+| `tikZstyle`                | `"inverted" \| "default"`  | Render TikZ diagrams normally or color-inverted (for dark themes).|
+| `blockquoteStyle`          | `"default" \| "latex"`     | Blockquote styling; `"latex"` renders LaTeX-style theorem boxes.   |
+| `numberedHeading`          | `boolean`                  | Automatically number section headings.                            |
+| `tocMarker`                | `boolean`                  | Show the active-section marker in the table of contents.          |
+
+Example:
+
+```tsx
+<Notie
+  markdown={markdown}
+  config={{
+    showTableOfContents: true,
+    tocTitle: "Contents",
+    fontSize: "16px",
+    theme: {
+      appearance: "dark",
+      blockquoteStyle: "latex",
+      numberedHeading: true,
+    },
+  }}
+/>
+```
 
 ## Showcase
 

--- a/demo-app/src/pages/tutorial.md
+++ b/demo-app/src/pages/tutorial.md
@@ -2,7 +2,7 @@
 
 <div class="subtitle">
 
-Updated for [v1.3](https://github.com/branyang02/notie/tree/a89c10cb3ad6201971f7e89fa24b58c3b6f96633).
+Updated for [v1.4](https://github.com/branyang02/notie).
 
 </div>
 
@@ -21,9 +21,11 @@ Then, import the `Notie` component in your React application:
 ```tsx
 import { Notie } from "notie-markdown";
 
-const Example = () => (
-  <Notie markdown="# Hello World\nThis is a Markdown content." />
-);
+const markdown = `# Hello World
+
+This is a Markdown content.`;
+
+const Example = () => <Notie markdown={markdown} />;
 ```
 
 The `Notie` component has the following props:
@@ -826,15 +828,15 @@ $$
 You can include images in your markdown file using the following syntax:
 
 ```markdown
-![Alt text](https://via.placeholder.com/150)
+![Alt text](https://placehold.co/150)
 ```
 
-![Alt text](https://via.placeholder.com/150)
+![Alt text](https://placehold.co/150)
 
 You can also make the images smaller by using HTML attributes:
 
 ```markdown
-<img src="https://via.placeholder.com/150" alt="placeholder" style="display: block; max-height: 30%; max-width: 30%;">
+<img src="https://placehold.co/150" alt="placeholder" style="display: block; max-height: 30%; max-width: 30%;">
 
 <div class="caption">
 
@@ -843,7 +845,7 @@ This is a placeholder image.
 </div>
 ```
 
-<img src="https://via.placeholder.com/150" alt="placeholder" style="display: block; max-height: 30%; max-width: 30%;">
+<img src="https://placehold.co/150" alt="placeholder" style="display: block; max-height: 30%; max-width: 30%;">
 
 <div class="caption">
 


### PR DESCRIPTION
## Problem

**Publish workflow (`.github/workflows/publish.yml`):**
- The workflow's own `ci: bump version ...` push to main re-triggers the workflow, causing an auto-republish loop.
- Version detection only inspected the first line of the commit message, and checked `^feat` before `BREAKING CHANGE` — so `feat: ... BREAKING CHANGE` subjects and footer-style breaking changes never bumped major.
- `npm publish` ran before the version-bump commit was pushed, so a failed push left npm ahead of git.
- Used `npm install` and `actions/checkout@v3` / `setup-node@v3`, out of step with `test.yml`.

**Docs:**
- README had no security guidance (raw HTML rendering via rehype-raw, remote code execution for `execute-` blocks, third-party TikZJax/Desmos scripts) and no configuration reference for `NotieConfig`.
- README and the tutorial both showed `markdown="# Hello World\nThis is..."`, which renders `\n` literally in JSX.
- Tutorial used dead `via.placeholder.com` image URLs and a stale "Updated for v1.3" stamp.

## Solution

**CI:**
- Job-level `if` skips runs whose head commit message starts with `ci: bump version`, breaking the loop.
- Version bump now checks `BREAKING CHANGE` anywhere in the full commit message first (major), then `^feat` (minor), then `^fix` (patch), with an explicit patch default.
- Reordered steps: version bump is committed and pushed **before** `npm publish` — a failed push fails the job before anything reaches npm.
- `npm install` → `npm ci`; `checkout`/`setup-node` bumped to v4 (matching `test.yml`). Auth/registry configuration and secrets usage unchanged.

**Docs:**
- README: new **Security** section (rehype-raw renders raw HTML by design — sanitize untrusted markdown; `execute-` blocks send code to the code execution endpoint, overridable via `config.codeRunnerUrl`; `tikz` blocks load the TikZJax engine from a pinned third-party URL; `desmos` blocks load the Desmos API script).
- README: new **Configuration reference** documenting `NotieConfig` and all `Theme` fields, verified against `src/config/NotieConfig.tsx` (incl. `blockquoteStyle`, `numberedHeading`, `tocMarker`, `tikZstyle`).
- README + tutorial: broken `\n` JSX example replaced with a template-literal example.
- Tutorial: `via.placeholder.com` → `placehold.co`; version stamp updated to v1.4.

## Tests

- `npm test`: 3 files, 10 tests passed.
- `npm run lint`: clean (0 warnings).
- `npm run build`: succeeds.
- `publish.yml` validated with `yaml.safe_load`.

## Risk

- Low for docs (content only, no code paths).
- CI changes alter the publish flow ordering; if `npm publish` fails after the bump commit is pushed, the version bump lands without a published package — recoverable by re-running publish manually, and strictly better than the previous failure mode (npm ahead of git). The skip condition only matches commits starting with `ci: bump version`, which only the workflow itself creates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)