### PR TITLE
perf: stabilize merged config identity; fix font-link injection/cleanup (NOTIE-005/032)

### DIFF
--- a/src/components/Notie.rerender.test.tsx
+++ b/src/components/Notie.rerender.test.tsx
@@ -1,0 +1,83 @@
+import { act, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MarkdownProcessor } from "../utils/MarkdownProcessor";
+import Notie from "./Notie";
+
+const markdown = `# Demo
+
+## First Section
+
+Some content.
+
+\`\`\`component
+{
+    componentName: "Widget"
+}
+\`\`\`
+`;
+
+describe("Notie config identity", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("does not reprocess markdown when a parent re-renders with an inline config object", async () => {
+        const processSpy = vi.spyOn(MarkdownProcessor.prototype, "process");
+
+        let triggerParentRender: () => void = () => {};
+        const Parent = () => {
+            const [, setTick] = useState(0);
+            triggerParentRender = () => setTick((tick) => tick + 1);
+            return (
+                <Notie
+                    markdown={markdown}
+                    config={{
+                        theme: {
+                            linkColor: "#ff0000",
+                            numberedHeading: true,
+                        },
+                    }}
+                    customComponents={{
+                        Widget: () => (
+                            <div data-testid="custom-widget">Widget</div>
+                        ),
+                    }}
+                />
+            );
+        };
+
+        render(<Parent />);
+        expect(screen.getByTestId("custom-widget")).toBeInTheDocument();
+        expect(processSpy).toHaveBeenCalledTimes(1);
+
+        // Multiple parent re-renders with a fresh inline config object each
+        // time must not invalidate the merged config nor reprocess markdown.
+        await act(async () => triggerParentRender());
+        await act(async () => triggerParentRender());
+        await act(async () => triggerParentRender());
+
+        expect(processSpy).toHaveBeenCalledTimes(1);
+        expect(screen.getByText("Some content.")).toBeInTheDocument();
+    });
+
+    it("reprocesses markdown when the config contents actually change", async () => {
+        const processSpy = vi.spyOn(MarkdownProcessor.prototype, "process");
+
+        const { rerender } = render(
+            <Notie
+                markdown={markdown}
+                config={{ theme: { numberedHeading: false } }}
+            />,
+        );
+        expect(processSpy).toHaveBeenCalledTimes(1);
+
+        rerender(
+            <Notie
+                markdown={markdown}
+                config={{ theme: { numberedHeading: true } }}
+            />,
+        );
+        expect(processSpy).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/components/Notie.tsx
+++ b/src/components/Notie.tsx
@@ -17,6 +17,7 @@ import MarkdownRenderer from "./MarkdownRenderer";
 import { MarkdownProcessor } from "../utils/MarkdownProcessor";
 import { NotieConfig, NotieThemes } from "../config/NotieConfig";
 import { useNotieConfig } from "../utils/useNotieConfig";
+import { useShallowStableObject } from "../utils/useShallowStableObject";
 import { extractTableOfContents } from "../utils/toc";
 
 export interface NotieProps {
@@ -32,9 +33,16 @@ const Notie: React.FC<NotieProps> = ({
     markdown,
     config: userConfig,
     theme = "default",
-    customComponents,
+    customComponents: userCustomComponents,
 }) => {
     const config = useNotieConfig(userConfig, theme);
+    // `customComponents` values are functions, so we cannot stabilize them
+    // structurally (e.g. via JSON). Instead, reuse the previous object
+    // identity when the object stays shallowly equal (same keys, same
+    // function references), so inline `customComponents={{...}}` literals do
+    // not invalidate memoized children on every parent render. Consumers who
+    // pass freshly created functions each render still opt out of memoization.
+    const customComponents = useShallowStableObject(userCustomComponents);
     const {
         markdownContent,
         markdownSections,

--- a/src/utils/useNotieConfig.test.tsx
+++ b/src/utils/useNotieConfig.test.tsx
@@ -1,0 +1,116 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NotieConfig, NotieThemes } from "../config/NotieConfig";
+import { useNotieConfig } from "./useNotieConfig";
+
+describe("useNotieConfig", () => {
+    it("returns a referentially stable config across re-renders with structurally equal inline configs", () => {
+        const makeConfig = (): NotieConfig => ({
+            fontSize: "1.2rem",
+            theme: {
+                linkColor: "#123456",
+                numberedHeading: true,
+            },
+        });
+
+        const { result, rerender } = renderHook(
+            ({ config }: { config: NotieConfig }) =>
+                useNotieConfig(config, "default"),
+            { initialProps: { config: makeConfig() } },
+        );
+
+        const firstResult = result.current;
+
+        // New object identity, same contents.
+        rerender({ config: makeConfig() });
+        expect(result.current).toBe(firstResult);
+
+        rerender({ config: makeConfig() });
+        expect(result.current).toBe(firstResult);
+
+        // Changed contents must produce a new merged config.
+        rerender({
+            config: { ...makeConfig(), fontSize: "2rem" },
+        });
+        expect(result.current).not.toBe(firstResult);
+        expect(result.current.fontSize).toBe("2rem");
+    });
+
+    it("keeps identity stable when no user config is provided", () => {
+        const { result, rerender } = renderHook(() =>
+            useNotieConfig(undefined, "default"),
+        );
+
+        const firstResult = result.current;
+        rerender();
+        expect(result.current).toBe(firstResult);
+    });
+
+    it("deep-merges a custom theme value into a predefined theme", () => {
+        const { result } = renderHook(() =>
+            useNotieConfig(
+                { theme: { linkColor: "#ff0000" } },
+                "Starlit Eclipse",
+            ),
+        );
+
+        // The overridden value is applied...
+        expect(result.current.theme.linkColor).toBe("#ff0000");
+        // ...while the rest of the Starlit Eclipse theme is preserved.
+        expect(result.current.theme.appearance).toBe("dark");
+        expect(result.current.theme.backgroundColor).toBe("rgb(3 7 18)");
+        expect(result.current.theme.fontFamily).toBe(
+            "'Space Grotesk', sans-serif",
+        );
+        expect(result.current.theme.linkHoverColor).toBe("#f472b6");
+        expect(result.current.theme.staticCodeTheme).toBe("github-dark");
+    });
+
+    describe("custom font links", () => {
+        const getFontLinks = (href: string) =>
+            Array.from(
+                document.head.querySelectorAll<HTMLLinkElement>(
+                    `link[rel="stylesheet"][href="${href}"]`,
+                ),
+            );
+
+        it("appends both the content and TOC font links and removes them on unmount", () => {
+            const fontUrl = "https://fonts.example.com/content-font.css";
+            const tocFontUrl = "https://fonts.example.com/toc-font.css";
+            const { unmount } = renderHook(() =>
+                useNotieConfig({
+                    theme: {
+                        customFontUrl: fontUrl,
+                        tocCustomFontUrl: tocFontUrl,
+                    },
+                }),
+            );
+
+            expect(getFontLinks(fontUrl)).toHaveLength(1);
+            expect(getFontLinks(tocFontUrl)).toHaveLength(1);
+
+            unmount();
+
+            expect(getFontLinks(fontUrl)).toHaveLength(0);
+            expect(getFontLinks(tocFontUrl)).toHaveLength(0);
+        });
+
+        it("loads both font links for a predefined theme that sets both URLs", () => {
+            const themeName: NotieThemes = "Starlit Eclipse";
+            const { result, unmount } = renderHook(() =>
+                useNotieConfig(undefined, themeName),
+            );
+
+            const { customFontUrl, tocCustomFontUrl } = result.current.theme;
+            expect(customFontUrl).toBeTruthy();
+            expect(tocCustomFontUrl).toBeTruthy();
+
+            // Both point at the same URL for this theme, so both links share it.
+            expect(customFontUrl).toBe(tocCustomFontUrl);
+            expect(getFontLinks(customFontUrl)).toHaveLength(2);
+
+            unmount();
+            expect(getFontLinks(customFontUrl)).toHaveLength(0);
+        });
+    });
+});

--- a/src/utils/useNotieConfig.ts
+++ b/src/utils/useNotieConfig.ts
@@ -168,17 +168,28 @@ export function useNotieConfig(
         }
     }, [userTheme]);
 
-    const mergedConfig = useMemo(
-        () => ({
+    // NotieConfig is plain, JSON-serializable data (strings/booleans), so a
+    // structural signature keeps the merged config referentially stable even
+    // when consumers pass a new inline `config={{...}}` object every render.
+    // Without this, a new config object identity would re-run the markdown
+    // processing pipeline in consumers on every parent render.
+    const userConfigSignature =
+        userConfig === undefined ? undefined : JSON.stringify(userConfig);
+
+    const mergedConfig = useMemo(() => {
+        const structuralUserConfig: NotieConfig | undefined =
+            userConfigSignature === undefined
+                ? undefined
+                : JSON.parse(userConfigSignature);
+        return {
             ...defaultNotieConfig,
-            ...userConfig,
+            ...structuralUserConfig,
             theme: {
                 ...selectedTheme,
-                ...userConfig?.theme,
+                ...structuralUserConfig?.theme,
             },
-        }),
-        [userConfig, selectedTheme],
-    );
+        };
+    }, [userConfigSignature, selectedTheme]);
 
     useEffect(() => {
         const root = document.documentElement;
@@ -286,29 +297,26 @@ export function useNotieConfig(
             mergedConfig.theme.tocMarker ? "true" : "false",
         );
 
-        // Handle custom font
-        const url = mergedConfig.theme.customFontUrl;
-        if (url) {
+        // Handle custom fonts: append a <link> for each configured font URL
+        // (main content and TOC) and remove all of them on cleanup.
+        const fontUrls = [
+            mergedConfig.theme.customFontUrl,
+            mergedConfig.theme.tocCustomFontUrl,
+        ].filter((fontUrl): fontUrl is string => Boolean(fontUrl));
+
+        const fontLinks = fontUrls.map((fontUrl) => {
             const fontLink = document.createElement("link");
-            fontLink.href = url;
+            fontLink.href = fontUrl;
             fontLink.rel = "stylesheet";
             document.head.appendChild(fontLink);
+            return fontLink;
+        });
 
-            return () => {
+        return () => {
+            fontLinks.forEach((fontLink) => {
                 document.head.removeChild(fontLink);
-            };
-        }
-        const tocUrl = mergedConfig.theme.tocCustomFontUrl;
-        if (tocUrl) {
-            const tocFontLink = document.createElement("link");
-            tocFontLink.href = tocUrl;
-            tocFontLink.rel = "stylesheet";
-            document.head.appendChild(tocFontLink);
-
-            return () => {
-                document.head.removeChild(tocFontLink);
-            };
-        }
+            });
+        };
     }, [mergedConfig]);
 
     return mergedConfig;

--- a/src/utils/useShallowStableObject.test.ts
+++ b/src/utils/useShallowStableObject.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useShallowStableObject } from "./useShallowStableObject";
+
+describe("useShallowStableObject", () => {
+    it("reuses the previous identity when the object is shallowly equal", () => {
+        const widget = () => null;
+        const { result, rerender } = renderHook(
+            ({ value }: { value: Record<string, unknown> | undefined }) =>
+                useShallowStableObject(value),
+            { initialProps: { value: { Widget: widget } } },
+        );
+
+        const first = result.current;
+        rerender({ value: { Widget: widget } });
+        expect(result.current).toBe(first);
+    });
+
+    it("returns a new identity when values change", () => {
+        const { result, rerender } = renderHook(
+            ({ value }: { value: Record<string, unknown> | undefined }) =>
+                useShallowStableObject(value),
+            { initialProps: { value: { Widget: () => null } } },
+        );
+
+        const first = result.current;
+        // New function reference means a genuinely different object.
+        rerender({ value: { Widget: () => null } });
+        expect(result.current).not.toBe(first);
+    });
+
+    it("returns a new identity when keys change", () => {
+        const widget = () => null;
+        const { result, rerender } = renderHook(
+            ({ value }: { value: Record<string, unknown> | undefined }) =>
+                useShallowStableObject(value),
+            { initialProps: { value: { Widget: widget } as Record<string, unknown> } },
+        );
+
+        const first = result.current;
+        rerender({ value: { Widget: widget, Other: widget } });
+        expect(result.current).not.toBe(first);
+    });
+
+    it("handles undefined values", () => {
+        const initialProps: { value: Record<string, unknown> | undefined } = {
+            value: undefined,
+        };
+        const { result, rerender } = renderHook(
+            ({ value }: { value: Record<string, unknown> | undefined }) =>
+                useShallowStableObject(value),
+            { initialProps },
+        );
+
+        expect(result.current).toBeUndefined();
+        rerender({ value: undefined });
+        expect(result.current).toBeUndefined();
+
+        const next = { Widget: () => null };
+        rerender({ value: next });
+        expect(result.current).toBe(next);
+    });
+});

--- a/src/utils/useShallowStableObject.ts
+++ b/src/utils/useShallowStableObject.ts
@@ -1,0 +1,38 @@
+import { useRef } from "react";
+
+function isShallowEqual<T extends Record<string, unknown>>(
+    a: T | undefined,
+    b: T | undefined,
+): boolean {
+    if (a === b) return true;
+    if (!a || !b) return false;
+
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) return false;
+
+    return aKeys.every(
+        (key) => Object.prototype.hasOwnProperty.call(b, key) && a[key] === b[key],
+    );
+}
+
+/**
+ * Returns a referentially stable object across re-renders as long as the
+ * provided object stays shallowly equal (same keys, same value references).
+ *
+ * Useful for props like `customComponents` whose values are functions and
+ * therefore cannot be structurally serialized: consumers often pass inline
+ * object literals (`customComponents={{ Widget }}`) which get a new identity
+ * every render even though their contents have not changed.
+ */
+export function useShallowStableObject<T extends Record<string, unknown>>(
+    value: T | undefined,
+): T | undefined {
+    const previousRef = useRef<T | undefined>(value);
+
+    if (!isShallowEqual(previousRef.current, value)) {
+        previousRef.current = value;
+    }
+
+    return previousRef.current;
+}


### PR DESCRIPTION
## Problem

**NOTIE-005 — Unstable config identity causes full markdown reprocess every render.**
`useNotieConfig` memoized the merged config on the `userConfig` object reference (`src/utils/useNotieConfig.ts`). Consumers passing an inline `config={{...}}` create a new object every parent render, which invalidated the memo, gave `mergedConfig` a new identity, and caused `MarkdownProcessor.process()` to re-run in `Notie.tsx`, the TOC to recompute, and every section to re-render — on every parent render. The same applied to inline `customComponents={{...}}` objects invalidating memoized children.

**NOTIE-032 — Font link effect bug.**
When `customFontUrl` was set, the effect returned early after appending its `<link>`, making the `tocCustomFontUrl` block unreachable — the TOC font never loaded when both were set (all Starlit themes set both). Cleanup was also tied to the early returns.

## Solution

- `useNotieConfig` now memoizes the merged config on a structural signature (`JSON.stringify`) of the user config plus the selected theme. `NotieConfig` is plain, JSON-serializable data (strings/booleans), so this is safe. The returned object stays referentially stable across renders when contents are equal; genuinely changed contents still produce a new object.
- `customComponents` values are functions, so structural serialization isn't possible. Added a `useShallowStableObject` hook (`src/utils/useShallowStableObject.ts`) that reuses the previous object identity when the object stays shallowly equal (same keys, same function references). `Notie.tsx` runs `customComponents` through it, with a comment documenting the behavior and its limits (freshly created functions per render still opt out).
- Font-link effect now appends a `<link>` for each configured URL (content and TOC) and returns a single cleanup that removes all appended links.

## Tests

- `src/components/Notie.rerender.test.tsx`: spies on `MarkdownProcessor.prototype.process`; a parent that re-renders 3x with fresh inline `config`/`customComponents` objects triggers exactly one `process()` call; changing config contents still reprocesses.
- `src/utils/useNotieConfig.test.tsx` (`renderHook`): stable identity across re-renders with structurally equal inline configs; stable with no config; theme deep-merge preserved (custom `linkColor` + "Starlit Eclipse" keeps other Starlit values); both font `<link>` elements appear in `document.head` when both URLs are set (explicit config and Starlit Eclipse theme) and both are removed on unmount.
- `src/utils/useShallowStableObject.test.ts`: identity reuse on shallow equality; new identity on value/key changes; undefined handling.
- `npm test` (21 tests, 6 files), `npm run lint`, `npm run build` all pass; existing tests unmodified.

## Risk

- Low. `JSON.stringify` key order follows object insertion order, so two configs with the same contents but different key order would produce different signatures — that only costs an extra (previously always-occurring) recompute, never a stale config.
- If a consumer passed non-serializable values into `config` (not expressible in the `NotieConfig` type), they would be dropped from the merged config; the type contract says plain data only.
- Behavior change for NOTIE-032 is strictly additive: the TOC font link now loads when both URLs are set, and cleanup removes exactly what was appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)