### PR TITLE
fix: configurable code-runner endpoint, timeout/abort, run-guard, execute-lang parsing (NOTIE-001/002/003)

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -28,10 +28,12 @@ const CodeBlock = ({
     initialCode,
     language = "python",
     theme,
+    codeRunnerUrl,
 }: {
     initialCode: string;
     language?: string;
     theme: string;
+    codeRunnerUrl?: string;
 }) => {
     const runCodeRef = useRef<() => void>(() => {});
 
@@ -95,15 +97,38 @@ const CodeBlock = ({
     const [code, setCode] = useState(initialCode);
     const [image, setImage] = useState("");
     const editorRef = useRef<ReactCodeMirrorRef>(null);
+    const isMountedRef = useRef(true);
+    const abortControllerRef = useRef<AbortController | null>(null);
+    const isRunPendingRef = useRef(false);
+
+    useEffect(() => {
+        isMountedRef.current = true;
+        return () => {
+            isMountedRef.current = false;
+            abortControllerRef.current?.abort();
+            abortControllerRef.current = null;
+        };
+    }, []);
 
     const onChange = useCallback((value: string) => {
         setCode(value);
     }, []);
 
     const runCodeAsync = useCallback(async () => {
+        // Guard against overlapping runs (e.g. Mod-Enter while loading).
+        if (isRunPendingRef.current) return;
+        isRunPendingRef.current = true;
+
+        const abortController = new AbortController();
+        abortControllerRef.current = abortController;
+
         setIsLoading(true);
         try {
-            const data: RunCodeResponse = await runCode(code, language);
+            const data: RunCodeResponse = await runCode(code, language, {
+                baseUrl: codeRunnerUrl,
+                signal: abortController.signal,
+            });
+            if (!isMountedRef.current) return;
             setError(
                 data.output.toLowerCase().includes("error") ||
                     data.output.toLowerCase().includes("exception"),
@@ -111,13 +136,22 @@ const CodeBlock = ({
             setOutput(data.output);
             setImage(data.image);
         } catch (error) {
-            setOutput(`Execution failed: ${error}`);
+            if (!isMountedRef.current) return;
+            const message =
+                error instanceof Error ? error.message : String(error);
+            setOutput(`Execution failed: ${message}`);
             setError(true);
             setImage("");
         } finally {
-            setIsLoading(false);
+            isRunPendingRef.current = false;
+            if (abortControllerRef.current === abortController) {
+                abortControllerRef.current = null;
+            }
+            if (isMountedRef.current) {
+                setIsLoading(false);
+            }
         }
-    }, [code, language]);
+    }, [code, language, codeRunnerUrl]);
 
     useEffect(() => {
         runCodeRef.current = runCodeAsync;

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -6,7 +6,11 @@ import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { katexOptions } from "../utils/katexOptions";
-import { BlockquoteMapping, EquationMapping } from "../utils/utils";
+import {
+    BlockquoteMapping,
+    EquationMapping,
+    parseExecuteLanguage,
+} from "../utils/utils";
 import BlockquoteReference from "./BlockquoteReference";
 import CodeBlock from "./CodeBlock";
 import DesmosGraph from "./DesmosGraph";
@@ -222,8 +226,11 @@ const MarkdownRenderer: React.FC<{
                                 <LazyRender minHeight={260}>
                                     <CodeBlock
                                         initialCode={code}
-                                        language={language.split("-").pop()}
+                                        language={parseExecuteLanguage(
+                                            language,
+                                        )}
                                         theme={config.theme.liveCodeTheme}
+                                        codeRunnerUrl={config.codeRunnerUrl}
                                     />
                                 </LazyRender>
                             );
@@ -287,6 +294,7 @@ const MarkdownRenderer: React.FC<{
             }),
             [
                 blockquoteMapping,
+                config.codeRunnerUrl,
                 config.previewBlockquotes,
                 config.previewEquations,
                 config.theme.liveCodeTheme,

--- a/src/config/NotieConfig.tsx
+++ b/src/config/NotieConfig.tsx
@@ -45,6 +45,8 @@ export interface NotieConfig {
     previewBlockquotes?: boolean;
     tocTitle?: string;
     fontSize?: CSSStyleDeclaration["fontSize"];
+    /** Base URL of the code-runner service used by executable code blocks. */
+    codeRunnerUrl?: string;
     theme?: Theme;
 }
 

--- a/src/service/api.test.ts
+++ b/src/service/api.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CODE_RUNNER_URL, runCode } from "./api";
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        ...init,
+    });
+}
+
+describe("runCode", () => {
+    const fetchMock = vi.fn<typeof fetch>();
+
+    beforeEach(() => {
+        fetchMock.mockReset();
+        vi.stubGlobal("fetch", fetchMock);
+        vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it("uses the default endpoint when no baseUrl is provided", async () => {
+        fetchMock.mockResolvedValue(
+            jsonResponse({ output: "hi", image: "" }),
+        );
+
+        const result = await runCode("print('hi')", "python");
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(
+            `${DEFAULT_CODE_RUNNER_URL}/api/coderunner`,
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    code: "print('hi')",
+                    language: "python",
+                }),
+            }),
+        );
+        expect(result).toEqual({ output: "hi", image: "" });
+    });
+
+    it("uses a custom endpoint when baseUrl is provided", async () => {
+        fetchMock.mockResolvedValue(
+            jsonResponse({ output: "ok", image: "" }),
+        );
+
+        await runCode("print('hi')", "python", {
+            baseUrl: "https://runner.example.com",
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://runner.example.com/api/coderunner",
+            expect.objectContaining({ method: "POST" }),
+        );
+    });
+
+    it("aborts the request when the timeout elapses", async () => {
+        vi.useFakeTimers();
+        fetchMock.mockImplementation(
+            (_url, init) =>
+                new Promise<Response>((_resolve, reject) => {
+                    init?.signal?.addEventListener("abort", () => {
+                        reject(
+                            (init.signal as AbortSignal).reason ??
+                                new Error("aborted"),
+                        );
+                    });
+                }),
+        );
+
+        const promise = runCode("while True: pass", "python", {
+            timeoutMs: 5000,
+        });
+        const assertion = expect(promise).rejects.toThrow(
+            "Code execution timed out after 5000ms",
+        );
+
+        await vi.advanceTimersByTimeAsync(5001);
+        await assertion;
+    });
+
+    it("aborts the request when an external signal is aborted", async () => {
+        fetchMock.mockImplementation(
+            (_url, init) =>
+                new Promise<Response>((_resolve, reject) => {
+                    init?.signal?.addEventListener("abort", () => {
+                        reject(
+                            (init.signal as AbortSignal).reason ??
+                                new Error("aborted"),
+                        );
+                    });
+                }),
+        );
+
+        const controller = new AbortController();
+        const promise = runCode("print('hi')", "python", {
+            signal: controller.signal,
+        });
+        const assertion = expect(promise).rejects.toThrow("unmounted");
+
+        controller.abort(new Error("unmounted"));
+        await assertion;
+    });
+
+    it("falls back to a status-based message for a non-JSON 502 response", async () => {
+        fetchMock.mockResolvedValue(
+            new Response("<html>Bad Gateway</html>", {
+                status: 502,
+                statusText: "Bad Gateway",
+                headers: { "Content-Type": "text/html" },
+            }),
+        );
+
+        await expect(runCode("print('hi')", "python")).rejects.toThrow(
+            "HTTP 502 Bad Gateway",
+        );
+    });
+
+    it("falls back to a status-based message when a JSON error body is malformed", async () => {
+        fetchMock.mockResolvedValue(
+            new Response("not-json", {
+                status: 500,
+                statusText: "Internal Server Error",
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+
+        await expect(runCode("print('hi')", "python")).rejects.toThrow(
+            "HTTP 500 Internal Server Error",
+        );
+    });
+
+    it("uses the server-provided error message when available", async () => {
+        fetchMock.mockResolvedValue(
+            jsonResponse(
+                { error: "Unsupported language" },
+                { status: 400, statusText: "Bad Request" },
+            ),
+        );
+
+        await expect(runCode("print('hi')", "brainfuck")).rejects.toThrow(
+            "Unsupported language",
+        );
+    });
+});

--- a/src/service/api.ts
+++ b/src/service/api.ts
@@ -3,12 +3,44 @@ export interface RunCodeResponse {
     image: string;
 }
 
-const baseUrl = "https://api.brandonyifanyang.com";
+export const DEFAULT_CODE_RUNNER_URL = "https://api.brandonyifanyang.com";
+export const DEFAULT_RUN_CODE_TIMEOUT_MS = 60_000;
+
+export interface RunCodeOptions {
+    /** Base URL of the code-runner service. Defaults to the public notie runner. */
+    baseUrl?: string;
+    /** Optional external signal to abort the request (e.g. on unmount). */
+    signal?: AbortSignal;
+    /** Request timeout in milliseconds. Defaults to 60s. */
+    timeoutMs?: number;
+}
 
 export const runCode = async (
     code: string,
     language: string,
+    options: RunCodeOptions = {},
 ): Promise<RunCodeResponse> => {
+    const {
+        baseUrl = DEFAULT_CODE_RUNNER_URL,
+        signal,
+        timeoutMs = DEFAULT_RUN_CODE_TIMEOUT_MS,
+    } = options;
+
+    const controller = new AbortController();
+    const onExternalAbort = () => controller.abort(signal?.reason);
+    if (signal) {
+        if (signal.aborted) {
+            controller.abort(signal.reason);
+        } else {
+            signal.addEventListener("abort", onExternalAbort, { once: true });
+        }
+    }
+    const timeoutId = setTimeout(() => {
+        controller.abort(
+            new Error(`Code execution timed out after ${timeoutMs}ms`),
+        );
+    }, timeoutMs);
+
     try {
         const response = await fetch(`${baseUrl}/api/coderunner`, {
             method: "POST",
@@ -16,16 +48,37 @@ export const runCode = async (
                 "Content-Type": "application/json",
             },
             body: JSON.stringify({ code, language }),
+            signal: controller.signal,
         });
 
         if (!response.ok) {
-            const errorData = await response.json();
-            throw new Error(errorData.error || "Unknown error occurred");
+            let message = `HTTP ${response.status} ${response.statusText}`.trim();
+            const contentType = response.headers.get("content-type") ?? "";
+            if (contentType.includes("application/json")) {
+                try {
+                    const errorData = await response.json();
+                    if (
+                        errorData &&
+                        typeof errorData === "object" &&
+                        typeof errorData.error === "string" &&
+                        errorData.error
+                    ) {
+                        message = errorData.error;
+                    }
+                } catch {
+                    // Body was not valid JSON despite the content type;
+                    // fall back to the status-based message.
+                }
+            }
+            throw new Error(message);
         }
         const data = await response.json();
         return data;
     } catch (error) {
         console.error("Failed to run code:", error);
         throw error;
+    } finally {
+        clearTimeout(timeoutId);
+        signal?.removeEventListener("abort", onExternalAbort);
     }
 };

--- a/src/utils/MarkdownProcessor.test.ts
+++ b/src/utils/MarkdownProcessor.test.ts
@@ -8,6 +8,7 @@ const config: FullNotieConfig = {
     previewBlockquotes: true,
     tocTitle: "Contents",
     fontSize: "1rem",
+    codeRunnerUrl: "https://api.brandonyifanyang.com",
     theme: {
         appearance: "light",
         backgroundColor: "#fff",

--- a/src/utils/useNotieConfig.ts
+++ b/src/utils/useNotieConfig.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from "react";
+import { DEFAULT_CODE_RUNNER_URL } from "../service/api";
 import {
     FullNotieConfig,
     FullTheme,
@@ -148,6 +149,7 @@ const defaultNotieConfig: FullNotieConfig = {
     previewBlockquotes: true,
     tocTitle: "Contents",
     fontSize: "1rem",
+    codeRunnerUrl: DEFAULT_CODE_RUNNER_URL,
     theme: defaultTheme,
 };
 

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { parseExecuteLanguage } from "./utils";
+
+describe("parseExecuteLanguage", () => {
+    it("strips the execute- prefix", () => {
+        expect(parseExecuteLanguage("execute-python")).toBe("python");
+        expect(parseExecuteLanguage("execute-java")).toBe("java");
+    });
+
+    it("preserves multi-part language names", () => {
+        expect(parseExecuteLanguage("execute-objective-c")).toBe(
+            "objective-c",
+        );
+        expect(parseExecuteLanguage("execute-c-sharp")).toBe("c-sharp");
+    });
+
+    it("only strips a leading prefix", () => {
+        expect(parseExecuteLanguage("execute-execute-python")).toBe(
+            "execute-python",
+        );
+        expect(parseExecuteLanguage("python")).toBe("python");
+    });
+});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,10 @@
+// Used in MarkdownRenderer.tsx for `execute-<language>` fenced code blocks.
+// Strips only the leading "execute-" prefix so multi-part language names
+// (e.g. "execute-objective-c") are preserved intact.
+export function parseExecuteLanguage(language: string): string {
+    return language.replace(/^execute-/, "");
+}
+
 export interface BlockquoteMapping {
     [label: string]: {
         blockquoteNumber: string;


### PR DESCRIPTION
## Problem

- **NOTIE-001**: `src/service/api.ts` hardcoded `https://api.brandonyifanyang.com` as the code-runner endpoint, so consumers could not point executable code blocks at their own runner.
- **NOTIE-002**: Code execution had several robustness gaps: no timeout or abort support (a hung runner spun forever), in-flight requests survived CodeBlock unmount and could setState on an unmounted component, Mod-Enter could fire overlapping runs while one was already loading, `!response.ok` blindly `await response.json()`-ed (crashing on non-JSON gateway errors like a 502 HTML page), and thrown errors were string-interpolated as `Execution failed: [object Object]`-style output.
- **NOTIE-003**: `MarkdownRenderer` parsed `execute-<lang>` fences with `language.split("-").pop()`, so `execute-objective-c` resolved to `c` instead of `objective-c`.

## Solution

- Added optional `codeRunnerUrl?: string` to `NotieConfig`; defaulted to the existing endpoint (`DEFAULT_CODE_RUNNER_URL` exported from `api.ts`) in `useNotieConfig`, and threaded through `MarkdownRenderer` -> `CodeBlock` -> `runCode`. Default behavior is unchanged.
- `runCode(code, language, options?)` now accepts `{ baseUrl, signal, timeoutMs }`. It creates an internal `AbortController` with a 60s default timeout and chains any external signal into it. On `!response.ok` it checks the `content-type` header and try-catches JSON parsing, falling back to `HTTP <status> <statusText>`.
- `CodeBlock` aborts the in-flight request on unmount, guards all setState calls behind an `isMountedRef`, early-returns from `runCodeAsync` while a run is pending (covers both the Run button and the Mod-Enter keymap, which share the same callback), and formats caught errors as `error instanceof Error ? error.message : String(error)`.
- Extracted a pure `parseExecuteLanguage` helper (`src/utils/utils.ts`) that strips only the leading `execute-` prefix, used by `MarkdownRenderer`. Non-execute fences are untouched.

## Tests run

- New `src/service/api.test.ts` (7 tests): default endpoint, custom endpoint, timeout abort (fake timers), external-signal abort, non-JSON 502 -> `HTTP 502 Bad Gateway`, malformed JSON body -> status fallback, server-provided JSON error message.
- New `src/utils/utils.test.ts` (3 tests): `execute-python` -> `python`, `execute-objective-c` -> `objective-c`, leading-prefix-only behavior.
- Existing tests untouched except `MarkdownProcessor.test.ts`, whose `FullNotieConfig` fixture needed the new required `codeRunnerUrl` field (no assertions changed).
- `npm test`: 5 files, 20 tests passed. `npm run lint`: clean (0 warnings). `npm run build`: passes.

## Risk

- Low. Default endpoint and success-path behavior are identical. Main behavioral changes: runs now time out after 60s (previously unbounded), overlapping runs are suppressed while one is pending, and error output text is cleaner. `FullNotieConfig` gains a required `codeRunnerUrl` field, which could affect external code constructing that internal type directly (the public `NotieConfig` field is optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)