### PR TITLE
fix(security): protocol-aware KaTeX trust and URL sanitization for markdown links (NOTIE-009/010)

### DIFF
--- a/src/components/BlockquoteReference.tsx
+++ b/src/components/BlockquoteReference.tsx
@@ -6,6 +6,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 
 import { katexOptions } from "../utils/katexOptions";
+import { sanitizeUrl } from "../utils/sanitizeUrl";
 import {
     BlockquoteMapping,
     EquationMapping,
@@ -173,6 +174,7 @@ const BlockquoteCard = ({
                 remarkPlugins={[remarkGfm, remarkMath]}
                 rehypePlugins={[[rehypeKatex, katexOptions]]}
                 components={components}
+                urlTransform={sanitizeUrl}
             >
                 {strippedContent}
             </ReactMarkdown>

--- a/src/components/EquationReference.tsx
+++ b/src/components/EquationReference.tsx
@@ -4,6 +4,7 @@ import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { katexOptions } from "../utils/katexOptions";
+import { sanitizeUrl } from "../utils/sanitizeUrl";
 import {
     EquationMapping,
     extractEquationInfo,
@@ -67,6 +68,7 @@ const EquationCard = ({ equationString }: { equationString: string }) => {
             <ReactMarkdown
                 remarkPlugins={[remarkGfm, remarkMath]}
                 rehypePlugins={[[rehypeKatex, katexOptions]]}
+                urlTransform={sanitizeUrl}
             >
                 {processedEquationString}
             </ReactMarkdown>

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -6,6 +6,7 @@ import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { katexOptions } from "../utils/katexOptions";
+import { sanitizeUrl } from "../utils/sanitizeUrl";
 import {
     BlockquoteMapping,
     EquationMapping,
@@ -332,6 +333,7 @@ const MarkdownSection = React.memo(
             remarkPlugins={[remarkGfm, remarkMath]}
             rehypePlugins={[[rehypeKatex, katexOptions], rehypeRaw, rehypeSlug]}
             components={components}
+            urlTransform={sanitizeUrl}
         >
             {markdownContent}
         </ReactMarkdown>

--- a/src/components/Notie.test.tsx
+++ b/src/components/Notie.test.tsx
@@ -295,4 +295,53 @@ New third section.
             screen.queryByText("New third section."),
         ).not.toBeInTheDocument();
     });
+
+    it("strips javascript: URLs from markdown links", () => {
+        const { container } = render(
+            <Notie
+                markdown={`# Demo
+
+[click me](javascript:alert(1))
+
+[obfuscated](JaVaScRiPt:alert(1))
+
+[safe](https://example.com)
+
+[anchor](#some-anchor)
+`}
+            />,
+        );
+
+        for (const anchor of Array.from(container.querySelectorAll("a"))) {
+            const href = anchor.getAttribute("href") ?? "";
+            expect(href.toLowerCase()).not.toContain("javascript:");
+        }
+
+        const safeLink = screen.getByRole("link", { name: "safe" });
+        expect(safeLink).toHaveAttribute("href", "https://example.com");
+        const anchorLink = screen.getByRole("link", { name: "anchor" });
+        expect(anchorLink).toHaveAttribute("href", "#some-anchor");
+    });
+
+    it("does not render javascript: hrefs from KaTeX \\href commands", () => {
+        const { container } = render(
+            <Notie
+                markdown={`# Demo
+
+$\\href{javascript:alert(1)}{evil}$
+
+$\\href{https://example.com}{good}$
+`}
+            />,
+        );
+
+        for (const anchor of Array.from(container.querySelectorAll("a"))) {
+            const href = anchor.getAttribute("href") ?? "";
+            expect(href.toLowerCase()).not.toContain("javascript:");
+        }
+
+        expect(
+            container.querySelector('a[href="https://example.com"]'),
+        ).not.toBeNull();
+    });
 });

--- a/src/utils/katexOptions.ts
+++ b/src/utils/katexOptions.ts
@@ -1,3 +1,13 @@
+/**
+ * Protocols allowed for `\href` commands. KaTeX resolves the protocol via
+ * `utils.protocolFromUrl` before invoking `trust`: it strips leading
+ * whitespace/control characters, lowercases the scheme, uses `"_relative"`
+ * for relative and fragment-only URLs (e.g. Notie's own `#pre-eqn-...`
+ * references), and rejects malformed schemes (returning `false` before
+ * `trust` is ever called).
+ */
+const ALLOWED_HREF_PROTOCOLS = ["http", "https", "mailto", "_relative"];
+
 export const katexOptions = {
     macros: {
         "\\eqref": "\\href{\\#pre-eqn-eqref:#1}{}",
@@ -5,6 +15,16 @@ export const katexOptions = {
         "\\label": "\\htmlId{#1}{}",
     },
     strict: false,
-    trust: (context: { command: string }) =>
-        ["\\htmlId", "\\href"].includes(context.command),
+    trust: (context: { command: string; protocol?: string }) => {
+        if (context.command === "\\htmlId") {
+            return true;
+        }
+        if (context.command === "\\href") {
+            return (
+                typeof context.protocol === "string" &&
+                ALLOWED_HREF_PROTOCOLS.includes(context.protocol)
+            );
+        }
+        return false;
+    },
 };

--- a/src/utils/sanitizeUrl.test.ts
+++ b/src/utils/sanitizeUrl.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeUrl } from "./sanitizeUrl";
+
+describe("sanitizeUrl", () => {
+    it("allows http and https URLs", () => {
+        expect(sanitizeUrl("http://example.com")).toBe("http://example.com");
+        expect(sanitizeUrl("https://example.com/a?b=c#d")).toBe(
+            "https://example.com/a?b=c#d",
+        );
+    });
+
+    it("allows mailto and tel URLs", () => {
+        expect(sanitizeUrl("mailto:test@example.com")).toBe(
+            "mailto:test@example.com",
+        );
+        expect(sanitizeUrl("tel:+15555550123")).toBe("tel:+15555550123");
+    });
+
+    it("allows relative URLs and fragments", () => {
+        expect(sanitizeUrl("/docs/page")).toBe("/docs/page");
+        expect(sanitizeUrl("./relative")).toBe("./relative");
+        expect(sanitizeUrl("relative/path")).toBe("relative/path");
+        expect(sanitizeUrl("#anchor")).toBe("#anchor");
+        expect(sanitizeUrl("#eqn-1.1")).toBe("#eqn-1.1");
+        expect(sanitizeUrl("?query=1")).toBe("?query=1");
+    });
+
+    it("blocks javascript: URLs", () => {
+        expect(sanitizeUrl("javascript:alert(1)")).toBe("");
+    });
+
+    it("blocks obfuscated javascript: URLs", () => {
+        expect(sanitizeUrl("JaVaScRiPt:alert(1)")).toBe("");
+        expect(sanitizeUrl(" javascript:alert(1)")).toBe("");
+        expect(sanitizeUrl("\tjavascript:alert(1)")).toBe("");
+        expect(sanitizeUrl("java\u0000script:alert(1)")).toBe("");
+        expect(sanitizeUrl("\u0001javascript:alert(1)")).toBe("");
+    });
+
+    it("blocks vbscript: and data:text/html URLs", () => {
+        expect(sanitizeUrl("vbscript:msgbox(1)")).toBe("");
+        expect(sanitizeUrl("data:text/html,<script>alert(1)</script>")).toBe(
+            "",
+        );
+        expect(
+            sanitizeUrl("data:text/html;base64,PHNjcmlwdD48L3NjcmlwdD4="),
+        ).toBe("");
+    });
+
+    it("blocks other unknown schemes", () => {
+        expect(sanitizeUrl("file:///etc/passwd")).toBe("");
+        expect(sanitizeUrl("ftp://example.com")).toBe("");
+    });
+
+    it("blocks data: URLs on links but allows data:image/* for image src", () => {
+        expect(sanitizeUrl("data:image/png;base64,iVBORw0K", "href")).toBe("");
+        expect(sanitizeUrl("data:image/png;base64,iVBORw0K")).toBe("");
+        expect(sanitizeUrl("data:image/png;base64,iVBORw0K", "src")).toBe(
+            "data:image/png;base64,iVBORw0K",
+        );
+        expect(sanitizeUrl("data:text/html,<script></script>", "src")).toBe("");
+    });
+});

--- a/src/utils/sanitizeUrl.ts
+++ b/src/utils/sanitizeUrl.ts
@@ -1,0 +1,44 @@
+import { defaultUrlTransform } from "react-markdown";
+
+/**
+ * `tel:` links are safe and commonly used, but are not covered by
+ * react-markdown's `defaultUrlTransform`.
+ */
+const TEL_URL = /^tel:/i;
+
+/**
+ * `data:image/*` URLs are safe when used as an image source (they cannot
+ * execute script in an `<img>` context), but must never be allowed on
+ * links, where `data:` URLs can be used for phishing or script execution.
+ */
+const DATA_IMAGE_URL = /^data:image\//i;
+
+/**
+ * URL transform for react-markdown that blocks dangerous URL schemes such as
+ * `javascript:`, `vbscript:`, and `data:` (e.g. `[x](javascript:alert(1))`).
+ *
+ * Wraps react-markdown's `defaultUrlTransform`, which allows `http(s)`,
+ * `mailto`, and relative/fragment/query URLs, and rejects everything else --
+ * including URLs whose scheme is obfuscated with mixed case, whitespace, or
+ * control characters. On top of that, this helper allows `tel:` links and
+ * `data:image/*` URLs for image sources (`src` attributes) only.
+ *
+ * Matches react-markdown's `UrlTransform` contract:
+ * `(url, key, node) => string` -- returning an empty string removes the URL.
+ */
+export function sanitizeUrl(url: string, key?: string): string {
+    const transformed = defaultUrlTransform(url);
+    if (transformed !== "") {
+        return transformed;
+    }
+
+    if (TEL_URL.test(url)) {
+        return url;
+    }
+
+    if (key === "src" && DATA_IMAGE_URL.test(url)) {
+        return url;
+    }
+
+    return "";
+}


### PR DESCRIPTION
## Problem

**NOTIE-009 — KaTeX trust callback bypasses forbiddenProtocols.** `src/utils/katexOptions.ts` returned `true` for every `\href` command regardless of URL, so markdown like `$\href{javascript:alert(1)}{x}$` rendered an anchor with a `javascript:` href.

**NOTIE-010 — no URL sanitizer on markdown links.** The three `ReactMarkdown` (v9) instances did not set `urlTransform`; while react-markdown's `defaultUrlTransform` applies when the prop is omitted, the components needed an explicit, shared, auditable policy — and `tel:` links plus `data:image/*` image sources (used by `CodeBlock`'s matplotlib output) were not covered by the default.

## Solution

- **KaTeX trust (`src/utils/katexOptions.ts`):** the trust callback is now protocol-aware. `\htmlId` is always trusted; `\href` is trusted only when `context.protocol` is `http`, `https`, `mailto`, or `_relative`. Verified against katex 0.16.11 in `node_modules`: KaTeX computes `protocol` via `protocolFromUrl` before calling `trust` (stripping leading whitespace/control chars, lowercasing the scheme, returning `_relative` for relative/fragment URLs, and rejecting malformed schemes outright), so Notie's own `\eqref`/`\ref` macros — which emit `#pre-eqn-...` relative hrefs — keep working.
- **Markdown URL sanitizer (`src/utils/sanitizeUrl.ts`):** shared `urlTransform` helper wired into all three `ReactMarkdown` instances (`MarkdownRenderer.tsx`, `BlockquoteReference.tsx`, `EquationReference.tsx`). It wraps react-markdown's exported `defaultUrlTransform` (allows http/https/mailto and relative/fragment/query URLs; robust to case, whitespace, and control-character obfuscation), and additionally allows `tel:` links and `data:image/*` URLs on `src` attributes only (never on links).

## Tests

- `src/utils/sanitizeUrl.test.ts` — unit tests: `javascript:`, `JaVaScRiPt:`, leading whitespace/tab, embedded NUL and leading control char, `vbscript:`, `data:text/html` (plain and base64), `file:`, `ftp:` all blocked; http/https/mailto/tel/relative/`#anchor`/`?query` allowed; `data:image/*` allowed only for `key === "src"`.
- `src/components/Notie.test.tsx` — rendering tests: `[x](javascript:alert(1))` and `$\href{javascript:alert(1)}{x}$` produce no `javascript:` hrefs in output, while safe https links, `#anchor` links, and `$\href{https://...}$` still render; all pre-existing tests (including `$\eqref{...}$` resolution and blockquote preview cards) pass unchanged.
- `npm test` (20/20 passed), `npm run lint` (clean), `npm run build` (success).

## Risk

Low. The KaTeX change only tightens which `\href` protocols are trusted; all internal macros use relative URLs (`_relative`) which remain allowed. The markdown change formalizes/extends react-markdown's default behavior rather than replacing it — the only behavioral additions are permitting `tel:` and `data:image/*` (src-only). Users linking exotic-but-safe schemes (e.g. `irc:`, `xmpp:` were in the default allow-list and remain allowed via `defaultUrlTransform`) are unaffected; any content relying on `javascript:`/`data:` links will now render dead links, which is the intended fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)