### PR TITLE
fix: pin TikZJax assets, retry-after-failure, error fallbacks, Desmos dark mode, starlit light TikZ style (NOTIE-021)

### DIFF
--- a/src/components/DesmosGraph.test.tsx
+++ b/src/components/DesmosGraph.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// DesmosGraph caches its script-loader promise at module scope, so import a
+// fresh copy for each test to avoid state leaking between tests.
+async function importDesmosGraph() {
+    vi.resetModules();
+    const module = await import("./DesmosGraph");
+    return module.default;
+}
+
+function stubDesmos() {
+    const destroy = vi.fn();
+    const setExpression = vi.fn();
+    const GraphingCalculator = vi.fn(() => ({ destroy, setExpression }));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).Desmos = { GraphingCalculator };
+
+    return { GraphingCalculator, destroy, setExpression };
+}
+
+describe("DesmosGraph", () => {
+    beforeEach(() => {
+        vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (window as any).Desmos;
+        document.head.innerHTML = "";
+        document.body.innerHTML = "";
+    });
+
+    it("creates the calculator without inverted colors by default", async () => {
+        const { GraphingCalculator } = stubDesmos();
+        const DesmosGraph = await importDesmosGraph();
+
+        render(<DesmosGraph graphScript="y=x" />);
+
+        await waitFor(() => {
+            expect(GraphingCalculator).toHaveBeenCalledTimes(1);
+        });
+        expect(GraphingCalculator).toHaveBeenCalledWith(
+            expect.any(HTMLElement),
+            { invertedColors: false },
+        );
+    });
+
+    it("creates the calculator with inverted colors in dark mode", async () => {
+        const { GraphingCalculator } = stubDesmos();
+        const DesmosGraph = await importDesmosGraph();
+
+        render(<DesmosGraph graphScript="y=x" appearance="dark" />);
+
+        await waitFor(() => {
+            expect(GraphingCalculator).toHaveBeenCalledTimes(1);
+        });
+        expect(GraphingCalculator).toHaveBeenCalledWith(
+            expect.any(HTMLElement),
+            { invertedColors: true },
+        );
+    });
+
+    it("sets one expression per non-empty line", async () => {
+        const { setExpression } = stubDesmos();
+        const DesmosGraph = await importDesmosGraph();
+
+        render(<DesmosGraph graphScript={"y=x\n\ny=x^2"} />);
+
+        await waitFor(() => {
+            expect(setExpression).toHaveBeenCalledTimes(2);
+        });
+        expect(setExpression).toHaveBeenNthCalledWith(1, {
+            id: "graph0",
+            latex: "y=x",
+        });
+        expect(setExpression).toHaveBeenNthCalledWith(2, {
+            id: "graph1",
+            latex: "y=x^2",
+        });
+    });
+
+    it("destroys the calculator on unmount", async () => {
+        const { GraphingCalculator, destroy } = stubDesmos();
+        const DesmosGraph = await importDesmosGraph();
+
+        const { unmount } = render(<DesmosGraph graphScript="y=x" />);
+
+        await waitFor(() => {
+            expect(GraphingCalculator).toHaveBeenCalledTimes(1);
+        });
+
+        unmount();
+        expect(destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders a fallback when the Desmos script fails to load", async () => {
+        const DesmosGraph = await importDesmosGraph();
+
+        // No window.Desmos stub: the component injects a <script> tag and
+        // waits for onload/onerror. Simulate a network failure.
+        const appendChild = vi
+            .spyOn(document.head, "appendChild")
+            .mockImplementation(((node: Node) => {
+                if (node instanceof HTMLScriptElement) {
+                    setTimeout(() => {
+                        node.onerror?.(new Event("error"));
+                    }, 0);
+                }
+                return node;
+            }) as typeof document.head.appendChild);
+
+        render(<DesmosGraph graphScript="y=x" />);
+
+        const fallback = await screen.findByTestId("desmos-fallback");
+        expect(fallback).toHaveTextContent("Failed to load Desmos");
+        expect(console.error).toHaveBeenCalled();
+
+        appendChild.mockRestore();
+    });
+});

--- a/src/components/DesmosGraph.tsx
+++ b/src/components/DesmosGraph.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Pane } from "evergreen-ui";
 import styles from "../styles/Notie.module.css";
 
@@ -11,7 +11,7 @@ function loadDesmosScript(): Promise<void> {
     if (typeof Desmos !== "undefined") return Promise.resolve();
 
     if (!desmosScriptPromise) {
-        desmosScriptPromise = new Promise((resolve, reject) => {
+        desmosScriptPromise = new Promise<void>((resolve, reject) => {
             const scriptEl = document.createElement("script");
             scriptEl.src =
                 "https://www.desmos.com/api/v1.9/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6";
@@ -20,19 +20,34 @@ function loadDesmosScript(): Promise<void> {
             scriptEl.onerror = () =>
                 reject(new Error("Failed to load Desmos script"));
             document.head.appendChild(scriptEl);
+        }).catch((error) => {
+            // Do not cache the rejection, so the next mount retries.
+            desmosScriptPromise = null;
+            throw error;
         });
     }
 
     return desmosScriptPromise;
 }
 
-const DesmosGraph = ({ graphScript }: { graphScript: string }) => {
+export interface DesmosGraphProps {
+    graphScript: string;
+    appearance?: "light" | "dark";
+}
+
+const DesmosGraph = ({
+    graphScript,
+    appearance = "light",
+}: DesmosGraphProps) => {
     const calculatorRef = useRef<HTMLDivElement | null>(null);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const calculatorInstance = useRef<any>(null); // Store the Desmos instance
+    const [loadFailed, setLoadFailed] = useState(false);
 
     useEffect(() => {
         let cancelled = false;
+
+        setLoadFailed(false);
 
         loadDesmosScript()
             .then(() => {
@@ -40,11 +55,16 @@ const DesmosGraph = ({ graphScript }: { graphScript: string }) => {
                 if (calculatorRef.current && !calculatorInstance.current) {
                     calculatorInstance.current = Desmos.GraphingCalculator(
                         calculatorRef.current,
+                        // Match the surrounding theme in dark mode.
+                        { invertedColors: appearance === "dark" },
                     );
                     updateExpressions();
                 }
             })
-            .catch((error) => console.error(error));
+            .catch((error) => {
+                console.error(error);
+                if (!cancelled) setLoadFailed(true);
+            });
 
         return () => {
             cancelled = true;
@@ -52,7 +72,7 @@ const DesmosGraph = ({ graphScript }: { graphScript: string }) => {
             calculatorInstance.current = null;
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [appearance]);
 
     // Update the calculator when graphScript changes
     useEffect(() => {
@@ -73,6 +93,18 @@ const DesmosGraph = ({ graphScript }: { graphScript: string }) => {
             });
         });
     };
+
+    if (loadFailed) {
+        return (
+            <Pane
+                maxWidth="100%"
+                className={styles["diagram-fallback"]}
+                data-testid="desmos-fallback"
+            >
+                <div>Failed to load Desmos.</div>
+            </Pane>
+        );
+    }
 
     return (
         <Pane

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -245,7 +245,10 @@ const MarkdownRenderer: React.FC<{
                         if (language === "desmos") {
                             return (
                                 <LazyRender minHeight={400}>
-                                    <DesmosGraph graphScript={code} />
+                                    <DesmosGraph
+                                        graphScript={code}
+                                        appearance={config.theme.appearance}
+                                    />
                                 </LazyRender>
                             );
                         }
@@ -297,6 +300,7 @@ const MarkdownRenderer: React.FC<{
                 config.codeRunnerUrl,
                 config.previewBlockquotes,
                 config.previewEquations,
+                config.theme.appearance,
                 config.theme.liveCodeTheme,
                 config.theme.staticCodeTheme,
                 customComponents,

--- a/src/components/TikZ.test.tsx
+++ b/src/components/TikZ.test.tsx
@@ -1,6 +1,7 @@
-import { render, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import TikZ from "./TikZ";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const PINNED_SHA = "1d1f0844bd918e09e7eac081f86a70ba28635301";
 
 function deferred<T>() {
     let resolve!: (value: T) => void;
@@ -11,9 +12,22 @@ function deferred<T>() {
     return { promise, resolve };
 }
 
+// TikZ caches loader promises at module scope, so import a fresh copy for
+// each test to avoid state leaking between tests.
+async function importTikZ() {
+    vi.resetModules();
+    const module = await import("./TikZ");
+    return module.default;
+}
+
 describe("TikZ", () => {
+    beforeEach(() => {
+        vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
     afterEach(() => {
         vi.unstubAllGlobals();
+        vi.restoreAllMocks();
         document.head.innerHTML = "";
         document.body.innerHTML = "";
     });
@@ -36,6 +50,7 @@ describe("TikZ", () => {
 
         vi.stubGlobal("fetch", fetchMock);
 
+        const TikZ = await importTikZ();
         const { container } = render(
             <TikZ tikzScript="\\begin{tikzpicture}\\end{tikzpicture}" />,
         );
@@ -49,5 +64,131 @@ describe("TikZ", () => {
                 container.querySelector('script[type="text/tikz"]'),
             ).toHaveTextContent("tikzpicture");
         });
+    });
+
+    it("fetches TikZJax assets pinned to a commit SHA instead of main", async () => {
+        const requestedUrls: string[] = [];
+        const fetchMock = vi.fn((url: string) => {
+            requestedUrls.push(url);
+            return Promise.resolve({
+                ok: true,
+                text: () => Promise.resolve(""),
+            });
+        });
+
+        vi.stubGlobal("fetch", fetchMock);
+
+        const TikZ = await importTikZ();
+        render(<TikZ tikzScript="\\begin{tikzpicture}\\end{tikzpicture}" />);
+
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+
+        const urls = requestedUrls;
+        for (const url of urls) {
+            expect(url).toContain(`/${PINNED_SHA}/`);
+            expect(url).not.toContain("/main/");
+        }
+    });
+
+    it("renders a fallback with the raw source when loading fails", async () => {
+        const fetchMock = vi.fn(() =>
+            Promise.reject(new Error("network down")),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const TikZ = await importTikZ();
+        const source = "\\begin{tikzpicture}\\draw (0,0);\\end{tikzpicture}";
+        render(<TikZ tikzScript={source} />);
+
+        const fallback = await screen.findByTestId("tikz-fallback");
+        expect(fallback).toHaveTextContent("TikZ rendering failed");
+        expect(fallback.querySelector("pre")).toHaveTextContent(
+            "\\draw (0,0);",
+        );
+        expect(console.error).toHaveBeenCalled();
+    });
+
+    it("retries loading on a new mount after a failure", async () => {
+        const failingFetch = vi.fn(() =>
+            Promise.reject(new Error("network down")),
+        );
+        vi.stubGlobal("fetch", failingFetch);
+
+        const TikZ = await importTikZ();
+        const { unmount } = render(
+            <TikZ tikzScript="\\begin{tikzpicture}\\end{tikzpicture}" />,
+        );
+
+        await screen.findByTestId("tikz-fallback");
+        expect(failingFetch).toHaveBeenCalledTimes(2);
+        unmount();
+
+        // The rejected promises must not be cached: a later mount should
+        // fetch again and succeed.
+        const succeedingFetch = vi.fn(() =>
+            Promise.resolve({
+                ok: true,
+                text: () => Promise.resolve(""),
+            }),
+        );
+        vi.stubGlobal("fetch", succeedingFetch);
+
+        const { container } = render(
+            <TikZ tikzScript="\\begin{tikzpicture}\\end{tikzpicture}" />,
+        );
+
+        await waitFor(() => {
+            expect(succeedingFetch).toHaveBeenCalledTimes(2);
+        });
+        await waitFor(() => {
+            expect(
+                container.querySelector('script[type="text/tikz"]'),
+            ).not.toBeNull();
+        });
+        expect(screen.queryByTestId("tikz-fallback")).toBeNull();
+    });
+
+    it("replaces the previous diagram when the source changes", async () => {
+        const fetchMock = vi.fn(() =>
+            Promise.resolve({
+                ok: true,
+                text: () => Promise.resolve(""),
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const TikZ = await importTikZ();
+        const { container, rerender } = render(
+            <TikZ tikzScript="\\begin{tikzpicture}A\\end{tikzpicture}" />,
+        );
+
+        await waitFor(() => {
+            expect(
+                container.querySelector('script[type="text/tikz"]'),
+            ).not.toBeNull();
+        });
+
+        // Simulate TikZJax replacing the script with a rendered SVG.
+        const tikzContainer = container.querySelector(
+            "div.tikz-drawing, [class*='tikz-drawing']",
+        ) as HTMLDivElement;
+        const staleSvg = document.createElementNS(
+            "http://www.w3.org/2000/svg",
+            "svg",
+        );
+        tikzContainer.appendChild(staleSvg);
+
+        rerender(<TikZ tikzScript="\\begin{tikzpicture}B\\end{tikzpicture}" />);
+
+        await waitFor(() => {
+            const scripts = tikzContainer.querySelectorAll(
+                'script[type="text/tikz"]',
+            );
+            expect(scripts).toHaveLength(1);
+            expect(scripts[0]).toHaveTextContent("B");
+        });
+        expect(tikzContainer.querySelector("svg")).toBeNull();
     });
 });

--- a/src/components/TikZ.tsx
+++ b/src/components/TikZ.tsx
@@ -1,15 +1,21 @@
 import { Pane } from "evergreen-ui";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import styles from "../styles/Notie.module.css";
+
+// TikZJax assets pinned to obsidian-tikzjax commit
+// 1d1f0844bd918e09e7eac081f86a70ba28635301 (main as of 2024-07-13) so that
+// upstream changes cannot break rendering.
+const TIKZJAX_CSS_URL =
+    "https://raw.githubusercontent.com/artisticat1/obsidian-tikzjax/1d1f0844bd918e09e7eac081f86a70ba28635301/styles.css";
+const TIKZJAX_SCRIPT_URL =
+    "https://raw.githubusercontent.com/artisticat1/obsidian-tikzjax/1d1f0844bd918e09e7eac081f86a70ba28635301/tikzjax.js";
 
 let tikzCssPromise: Promise<void> | null = null;
 let tikzScriptPromise: Promise<void> | null = null;
 
 function loadTikzCss(): Promise<void> {
     if (!tikzCssPromise) {
-        tikzCssPromise = fetch(
-            "https://raw.githubusercontent.com/artisticat1/obsidian-tikzjax/main/styles.css",
-        )
+        tikzCssPromise = fetch(TIKZJAX_CSS_URL)
             .then((response) => {
                 if (response.ok) return response.text();
                 throw new Error("Failed to load CSS");
@@ -18,6 +24,11 @@ function loadTikzCss(): Promise<void> {
                 const styleEl = document.createElement("style");
                 styleEl.textContent = cssContent;
                 document.head.appendChild(styleEl);
+            })
+            .catch((error) => {
+                // Do not cache the rejection, so the next mount retries.
+                tikzCssPromise = null;
+                throw error;
             });
     }
 
@@ -26,9 +37,7 @@ function loadTikzCss(): Promise<void> {
 
 function loadTikzScript(): Promise<void> {
     if (!tikzScriptPromise) {
-        tikzScriptPromise = fetch(
-            "https://raw.githubusercontent.com/artisticat1/obsidian-tikzjax/main/tikzjax.js",
-        )
+        tikzScriptPromise = fetch(TIKZJAX_SCRIPT_URL)
             .then((response) => {
                 if (response.ok) return response.text();
                 throw new Error("Failed to load script");
@@ -37,6 +46,11 @@ function loadTikzScript(): Promise<void> {
                 const scriptEl = document.createElement("script");
                 scriptEl.textContent = scriptContent;
                 document.body.appendChild(scriptEl);
+            })
+            .catch((error) => {
+                // Do not cache the rejection, so the next mount retries.
+                tikzScriptPromise = null;
+                throw error;
             });
     }
 
@@ -59,13 +73,14 @@ function tidyTikzSource(tikzSource: string) {
     return lines.join("\n");
 }
 
-function removeTikzScripts(container: HTMLDivElement | null) {
+function clearContainer(container: HTMLDivElement | null) {
     if (!container) return;
 
-    const existingScripts = container.querySelectorAll(
-        'script[type="text/tikz"]',
-    );
-    existingScripts.forEach((script) => script.remove());
+    // Remove both pending text/tikz scripts and previously rendered SVGs so
+    // diagrams do not stack up when the source changes.
+    while (container.firstChild) {
+        container.removeChild(container.firstChild);
+    }
 }
 
 function waitForNextFrame(): Promise<void> {
@@ -78,10 +93,13 @@ function waitForNextFrame(): Promise<void> {
 
 const TikZ = ({ tikzScript }: { tikzScript: string }) => {
     const scriptContainerRef = useRef<HTMLDivElement>(null);
+    const [loadFailed, setLoadFailed] = useState(false);
 
     useEffect(() => {
         const container = scriptContainerRef.current;
         let isCancelled = false;
+
+        setLoadFailed(false);
 
         async function renderTikz() {
             try {
@@ -89,6 +107,7 @@ const TikZ = ({ tikzScript }: { tikzScript: string }) => {
                 await waitForNextFrame();
             } catch (error) {
                 console.error("Failed to load TikZJax", error);
+                if (!isCancelled) setLoadFailed(true);
                 return;
             }
 
@@ -102,7 +121,7 @@ const TikZ = ({ tikzScript }: { tikzScript: string }) => {
 
             // TikZJax registers a MutationObserver after its loader runs, so
             // append only after the loader promise resolves.
-            removeTikzScripts(container);
+            clearContainer(container);
             container.appendChild(scriptEl);
         }
 
@@ -110,20 +129,32 @@ const TikZ = ({ tikzScript }: { tikzScript: string }) => {
 
         return () => {
             isCancelled = true;
-            removeTikzScripts(container);
+            clearContainer(container);
         };
     }, [tikzScript]);
 
     return (
-        <Pane
-            ref={scriptContainerRef}
-            display="flex"
-            justifyContent="center"
-            alignItems="center"
-            flexGrow={1}
-            maxWidth="100%"
-            className={styles["tikz-drawing"]}
-        ></Pane>
+        <>
+            {loadFailed && (
+                <Pane
+                    maxWidth="100%"
+                    className={styles["diagram-fallback"]}
+                    data-testid="tikz-fallback"
+                >
+                    <div>TikZ rendering failed. Showing source instead.</div>
+                    <pre>{tikzScript}</pre>
+                </Pane>
+            )}
+            <Pane
+                ref={scriptContainerRef}
+                display={loadFailed ? "none" : "flex"}
+                justifyContent="center"
+                alignItems="center"
+                flexGrow={1}
+                maxWidth="100%"
+                className={styles["tikz-drawing"]}
+            ></Pane>
+        </>
     );
 };
 

--- a/src/styles/Notie.module.css
+++ b/src/styles/Notie.module.css
@@ -131,6 +131,26 @@
     filter: var(--blog-tikz-style);
 }
 
+/* Fallback shown when TikZ or Desmos assets fail to load. */
+/* Used in TikZ.tsx and DesmosGraph.tsx */
+.diagram-fallback {
+    margin: 16px auto;
+    padding: 10px;
+    border: 1px dashed var(--blog-table-border-color);
+    border-radius: 6px;
+    color: var(--blog-caption-color);
+    font-size: 0.9em;
+}
+
+.diagram-fallback pre {
+    margin: 8px 0 0;
+    padding: 8px;
+    overflow-x: auto;
+    background-color: var(--blog-code-background-color);
+    color: var(--blog-code-color);
+    border-radius: 6px;
+}
+
 .code-blocks {
     font-size: var(--blog-code-font-size);
 }


### PR DESCRIPTION
## Problem

- **Unpinned upstream assets**: `TikZ.tsx` fetched `styles.css` and `tikzjax.js` from the `main` branch of `artisticat1/obsidian-tikzjax`, so any upstream change could silently break TikZ rendering.
- **Rejected-promise poisoning**: the module-level loader promises in `TikZ.tsx` and `DesmosGraph.tsx` cached rejections forever — a single transient network failure permanently broke all TikZ/Desmos diagrams until a full page reload.
- **Blank pane on failure**: load failures only hit `console.error` and left an empty pane with no user-visible indication.
- **SVG stacking**: `removeTikzScripts` only removed `script[type="text/tikz"]` nodes, so previously rendered SVGs accumulated in the container on prop change.
- **Desmos ignores theme**: `Desmos.GraphingCalculator(el)` was created with no options, producing a bright white box in dark themes.
- Ticket item 5 (starlitEclipseLight `tikZstyle: "inverted"`) is already fixed on `agent-orchestra`: `starlitEclipseLight` has `tikZstyle: "default"`; the `"inverted"` at line ~105 belongs to `defaultDarkTheme`, which is correct. No change was needed.

## Solution

- Pinned both TikZJax asset URLs to immutable commit `1d1f0844bd918e09e7eac081f86a70ba28635301` (upstream `main` HEAD, committed 2024-07-13), with a comment noting the pinned version.
- On loader rejection, the cached promise is reset to `null` before rethrowing, so the next mount retries the fetch.
- Added error states: TikZ renders a "TikZ rendering failed" note plus the raw TikZ source in a `<pre>`; Desmos renders a "Failed to load Desmos." note. Both use a new `.diagram-fallback` style driven by existing theme CSS variables. `console.error` is kept.
- TikZ now clears all container children (scripts and rendered SVGs) on re-render/unmount, so only the current diagram shows.
- `DesmosGraph` accepts a new optional `appearance` prop ("light" | "dark", default "light") threaded from `MarkdownRenderer` via `config.theme.appearance`, and passes `{ invertedColors: true }` to `Desmos.GraphingCalculator` in dark mode.

## Tests

- `TikZ.test.tsx` extended: pinned-URL assertion (SHA present, no `/main/`), failure renders fallback UI with raw source, second mount after failure retries the fetch and succeeds, re-render replaces stale SVG/scripts. Existing loader-ordering test preserved (now with per-test module isolation).
- New `DesmosGraph.test.tsx` with a stubbed `window.Desmos`: `GraphingCalculator` called with `invertedColors: false`/`true` per appearance, `setExpression` called per non-empty line, `destroy` called on unmount, script `onerror` renders fallback UI.
- `npm test` (19 passed), `npm run lint` (clean), `npm run build` (passes).

## Risk

- **User-visible UI change**: load failures now show small fallback notes instead of a blank pane, and Desmos graphs render with inverted colors in dark themes.
- Pinning freezes TikZJax behavior at the 2024-07-13 upstream commit; future upstream fixes require a deliberate SHA bump.
- `DesmosGraph`'s init effect now re-runs if `appearance` changes at runtime (calculator is destroyed and recreated), which also re-applies expressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)