### PR TITLE
fix: document-level code/comment masking in MarkdownProcessor; fence-aware sections, TOC, and equation scanning (NOTIE-020)

### DIFF
--- a/src/utils/MarkdownProcessor.test.ts
+++ b/src/utils/MarkdownProcessor.test.ts
@@ -116,3 +116,301 @@ $$
         errorSpy.mockRestore();
     });
 });
+
+describe("MarkdownProcessor document-level masking", () => {
+    it("does not split sections on '## ' lines inside fenced code blocks", () => {
+        const fence = [
+            "```bash",
+            "## comment inside code",
+            "echo hello",
+            "```",
+        ].join("\n");
+        const markdown = `# Title
+
+## Section One
+
+Some prose.
+
+${fence}
+
+## Section Two
+
+More prose.
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        // Title section + two real sections; the '## ' line inside the
+        // fence must not create a fourth section.
+        expect(result.markdownSections).toHaveLength(3);
+        // The fence survives intact, in a single section.
+        expect(result.markdownSections[1]).toContain(fence);
+        expect(result.markdownContent).toContain(fence);
+        // No mapping pollution.
+        expect(result.equationMapping).toEqual({});
+        expect(result.blockquoteMapping).toEqual({});
+    });
+
+    it("ignores labels and blockquotes inside fenced code blocks", () => {
+        const markdown = `# Title
+
+## Section
+
+\`\`\`tex
+$$
+\\begin{equation} \\label{eq:fake}
+x = 1
+\\end{equation}
+$$
+<blockquote class="theorem" id="thm:fake">Fake</blockquote>
+\`\`\`
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.equationMapping).toEqual({});
+        expect(result.blockquoteMapping).toEqual({});
+    });
+
+    it("ignores labels inside indented code blocks", () => {
+        const markdown = [
+            "# Title",
+            "",
+            "## Section",
+            "",
+            "    $$",
+            "    \\begin{equation} \\label{eq:indented}",
+            "    x = 1",
+            "    \\end{equation}",
+            "    $$",
+            "",
+            "Prose after.",
+            "",
+        ].join("\n");
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.equationMapping).toEqual({});
+        expect(result.markdownContent).toContain(
+            "    \\begin{equation} \\label{eq:indented}",
+        );
+    });
+
+    it("does not let a stray ``` in prose swallow later content", () => {
+        const markdown = `# Title
+
+## Section
+
+This paragraph mentions a stray fence marker below.
+
+\`\`\`
+
+$$
+\\begin{equation} \\label{eq:visible}
+x = 1
+\\end{equation}
+$$
+
+Trailing prose stays intact.
+`;
+
+        // The stray \`\`\` opens an unterminated fence that runs to EOF, so
+        // everything after it is code: the label must NOT be mapped, and
+        // the raw text must survive verbatim.
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.equationMapping).toEqual({});
+        expect(result.markdownContent).toContain(
+            "This paragraph mentions a stray fence marker below.",
+        );
+        expect(result.markdownContent).toContain(
+            "Trailing prose stays intact.",
+        );
+    });
+
+    it("does not pair a stray ``` in prose with a later real fence", () => {
+        const markdown = `# Title
+
+## Section
+
+Stray marker: \`\`\` appears mid-line here.
+
+$$
+\\begin{equation} \\label{eq:real}
+x = 1
+\\end{equation}
+$$
+
+\`\`\`tex
+\\label{eq:in-code}
+\`\`\`
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        // The inline \`\`\` is not at line start, so it is not a fence: the
+        // real equation is mapped, while the label inside the real fence
+        // is not.
+        expect(Object.keys(result.equationMapping)).toEqual(["eq:real"]);
+        expect(result.markdownContent).toContain(
+            "Stray marker: ``` appears mid-line here.",
+        );
+    });
+
+    it("ignores blockquotes inside HTML comments and keeps counters intact", () => {
+        const markdown = `# Title
+
+## Section
+
+<!-- <blockquote class="theorem" id="thm:ghost">Ghost</blockquote> -->
+
+<blockquote class="theorem" id="thm:real">
+Real theorem.
+</blockquote>
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        // No ghost entry, and the real theorem is numbered x.1 (the
+        // commented-out blockquote must not increment the counter).
+        expect(Object.keys(result.blockquoteMapping)).toEqual(["thm:real"]);
+        expect(result.blockquoteMapping["thm:real"].blockquoteNumber).toBe(
+            "1.1",
+        );
+        expect(result.markdownContent).toContain(
+            '<!-- <blockquote class="theorem" id="thm:ghost">Ghost</blockquote> -->',
+        );
+    });
+
+    it("maps labels in single-line $$\\begin{equation}...\\end{equation}$$ blocks", () => {
+        const markdown = `# Title
+
+## Section
+
+$$\\begin{equation}\\label{eq:a} x = 1 \\end{equation}$$
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.equationMapping["eq:a"]).toBeDefined();
+        expect(result.equationMapping["eq:a"].equationNumber).toBe("1.1");
+        expect(result.equationMapping["eq:a"].equationString).toContain(
+            "x = 1",
+        );
+    });
+
+    it("counts single-line and multi-line equations in document order", () => {
+        const markdown = `# Title
+
+## Section
+
+$$\\begin{equation}\\label{eq:first} x = 1 \\end{equation}$$
+
+$$
+\\begin{equation} \\label{eq:second}
+y = 2
+\\end{equation}
+$$
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.equationMapping["eq:first"].equationNumber).toBe("1.1");
+        expect(result.equationMapping["eq:second"].equationNumber).toBe("1.2");
+    });
+
+    it("does not number headings inside fenced code blocks", () => {
+        const markdown = `# Title
+
+## Real Heading
+
+\`\`\`markdown
+## Fake Heading
+### Another Fake
+\`\`\`
+
+### Real Subheading
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.markdownContent).toContain(
+            "## 1&nbsp;&nbsp;&nbsp;Real Heading",
+        );
+        expect(result.markdownContent).toContain(
+            "### 1.1&nbsp;&nbsp;&nbsp;Real Subheading",
+        );
+        // Headings inside the fence stay untouched.
+        expect(result.markdownContent).toContain("## Fake Heading");
+        expect(result.markdownContent).toContain("### Another Fake");
+        expect(result.markdownContent).not.toContain(
+            "## 2&nbsp;&nbsp;&nbsp;Fake Heading",
+        );
+    });
+
+    it("round-trips a complex document without losing code or comments", () => {
+        const backtickFence = [
+            "```python",
+            "## not a heading",
+            "def f():",
+            '    return "$$\\\\label{eq:code}"',
+            "```",
+        ].join("\n");
+        const tildeFence = [
+            "~~~text",
+            "### also not a heading",
+            '<blockquote class="definition" id="def:code">nope</blockquote>',
+            "~~~",
+        ].join("\n");
+        const indented = [
+            "    indented code line one",
+            "    \\label{eq:indented-code}",
+        ].join("\n");
+        const comment = "<!-- hidden ## heading and \\label{eq:comment} -->";
+
+        const markdown = `# Title
+
+## Alpha
+
+${backtickFence}
+
+$$
+\\begin{equation} \\label{eq:alpha}
+a = 1
+\\end{equation}
+$$
+
+${comment}
+
+## Beta
+
+${tildeFence}
+
+${indented}
+
+<blockquote class="theorem" id="thm:beta">
+Beta theorem.
+</blockquote>
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        // All protected content is restored verbatim.
+        expect(result.markdownContent).toContain(backtickFence);
+        expect(result.markdownContent).toContain(tildeFence);
+        expect(result.markdownContent).toContain(indented);
+        expect(result.markdownContent).toContain(comment);
+
+        // Only real constructs are mapped.
+        expect(Object.keys(result.equationMapping)).toEqual(["eq:alpha"]);
+        expect(result.equationMapping["eq:alpha"].equationNumber).toBe("1.1");
+        expect(Object.keys(result.blockquoteMapping)).toEqual(["thm:beta"]);
+        expect(result.blockquoteMapping["thm:beta"].blockquoteNumber).toBe(
+            "2.1",
+        );
+
+        // Section structure: title + Alpha + Beta.
+        expect(result.markdownSections).toHaveLength(3);
+        expect(result.markdownContent).toBe(result.markdownSections.join(""));
+    });
+});

--- a/src/utils/MarkdownProcessor.ts
+++ b/src/utils/MarkdownProcessor.ts
@@ -1,4 +1,5 @@
 import { NotieConfig } from "../config/NotieConfig";
+import { maskProtectedRegions } from "./markdownMasking";
 import { BlockquoteMapping, EquationMapping } from "./utils";
 
 export class MarkdownProcessor {
@@ -18,26 +19,36 @@ export class MarkdownProcessor {
         equationMapping: EquationMapping;
         blockquoteMapping: BlockquoteMapping;
     } {
-        const sections = this.splitIntoSections();
-        const processedSections = sections.map((section, i) => {
+        // Mask fenced/indented code blocks and HTML comments at the document
+        // level so that section splitting, equation/blockquote scanning, and
+        // heading numbering never see their contents.
+        const { maskedText, unmask } = maskProtectedRegions(
+            this.markdownContent,
+        );
+
+        const sections = this.splitIntoSections(maskedText);
+        let processedSections = sections.map((section, i) => {
             section = i === 0 ? section : this.wrapInDiv(section, i); // Do not process the first section under Title
             return this.processSection(section, i);
         });
 
         if (this.config.theme?.numberedHeading) {
-            const numberedSections =
+            processedSections =
                 this.addHeadingNumbersToSections(processedSections);
-            return {
-                markdownContent: numberedSections.join(""),
-                markdownSections: numberedSections,
-                equationMapping: this.equationMapping,
-                blockquoteMapping: this.blockquoteMapping,
-            };
+        }
+
+        // Restore the original code/comment content before returning.
+        const restoredSections = processedSections.map(unmask);
+        for (const mapping of Object.values(this.equationMapping)) {
+            mapping.equationString = unmask(mapping.equationString);
+        }
+        for (const mapping of Object.values(this.blockquoteMapping)) {
+            mapping.blockquoteContent = unmask(mapping.blockquoteContent);
         }
 
         return {
-            markdownContent: processedSections.join(""),
-            markdownSections: processedSections,
+            markdownContent: restoredSections.join(""),
+            markdownSections: restoredSections,
             equationMapping: this.equationMapping,
             blockquoteMapping: this.blockquoteMapping,
         };
@@ -62,8 +73,8 @@ export class MarkdownProcessor {
         );
     }
 
-    private splitIntoSections(): string[] {
-        return this.markdownContent.split(/(?=^##\s)/gm).filter(Boolean);
+    private splitIntoSections(content: string): string[] {
+        return content.split(/(?=^##\s)/gm).filter(Boolean);
     }
 
     private wrapInDiv(content: string, sectionIndex: number): string {
@@ -74,14 +85,14 @@ export class MarkdownProcessor {
         sectionContent: string,
         sectionIndex: number,
     ): string {
-        const { modifiedContent, codeBlocks } =
-            this.extractCodeBlocks(sectionContent);
+        // Code blocks and HTML comments are already masked at the document
+        // level (see process()), so the scanners below never see them.
         const finalContent = this.processEquations(
-            modifiedContent,
+            sectionContent,
             sectionIndex,
         );
-        this.processBlockquotes(modifiedContent, sectionIndex);
-        return this.reinsertCodeBlocks(finalContent, codeBlocks);
+        this.processBlockquotes(sectionContent, sectionIndex);
+        return finalContent;
     }
 
     private processBlockquotes(content: string, sectionIndex: number): void {
@@ -133,8 +144,11 @@ export class MarkdownProcessor {
     }
 
     private processEquations(content: string, sectionIndex: number): string {
+        // Matches both multi-line ($$\n\begin{...}...) and single-line
+        // ($$\begin{...}...\end{...}$$) display environments, with optional
+        // whitespace between the delimiters and the environment.
         const equationPattern =
-            /\$\$\n(?:\s*\\begin\{(equation|align)\}[\s\S]*?\n\s*\\end\{\1\}\s*\$\$)/g;
+            /\$\$\s*\\begin\{(equation|align)\}[\s\S]*?\\end\{\1\}\s*\$\$/g;
         const equations = content.match(equationPattern);
         let currEquationNumber = 1;
 
@@ -255,25 +269,5 @@ export class MarkdownProcessor {
                 };
             }
         }
-    }
-
-    private extractCodeBlocks(content: string): {
-        modifiedContent: string;
-        codeBlocks: string[];
-    } {
-        const codeBlockPattern = /```[\s\S]*?```/g;
-        const codeBlocks: string[] = [];
-        const modifiedContent = content.replace(codeBlockPattern, (match) => {
-            codeBlocks.push(match);
-            return `CODE_BLOCK_${codeBlocks.length - 1}`;
-        });
-        return { modifiedContent, codeBlocks };
-    }
-
-    private reinsertCodeBlocks(content: string, codeBlocks: string[]): string {
-        return content.replace(
-            /CODE_BLOCK_(\d+)/g,
-            (_, index) => codeBlocks[Number(index)],
-        );
     }
 }

--- a/src/utils/markdownMasking.ts
+++ b/src/utils/markdownMasking.ts
@@ -1,0 +1,131 @@
+/**
+ * Document-level masking of "protected" markdown regions (fenced code
+ * blocks, indented code blocks, and HTML comments) so that downstream
+ * regex-based processing (section splitting, equation/blockquote scanning,
+ * heading numbering, table-of-contents extraction) never sees their
+ * contents.
+ *
+ * Each protected region is replaced with a unique placeholder token that:
+ * - cannot collide with document content (the token base is grown until it
+ *   does not occur in the source text),
+ * - never starts a line with `#` or contains backticks, so it survives
+ *   section splitting and is not transformed by later regexes.
+ */
+
+export interface MaskResult {
+    /** The document with all protected regions replaced by tokens. */
+    maskedText: string;
+    /** Restores the original text for every token found in the input. */
+    unmask: (text: string) => string;
+}
+
+const isBlank = (line: string): boolean => line.trim() === "";
+
+const isIndentedCodeLine = (line: string): boolean =>
+    /^(?: {4}|\t)/.test(line) && !isBlank(line);
+
+export function maskProtectedRegions(text: string): MaskResult {
+    // Grow the token base until it cannot collide with document content.
+    let base = "NOTIEMASK";
+    while (text.includes(base)) {
+        base += "X";
+    }
+
+    const store: string[] = [];
+    const makeToken = (original: string): string => {
+        store.push(original);
+        return `${base}${store.length - 1}${base}`;
+    };
+
+    const lines = text.split("\n");
+    const out: string[] = [];
+    let i = 0;
+
+    while (i < lines.length) {
+        const line = lines[i];
+
+        // Fenced code block: opening fence of 3+ backticks or tildes at line
+        // start (up to 3 spaces of indentation) with an optional info string.
+        // Per CommonMark, a backtick fence's info string may not contain a
+        // backtick (that would be an inline code span instead).
+        const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+        const isFenceOpen =
+            fenceMatch !== null &&
+            !(fenceMatch[1][0] === "`" && fenceMatch[2].includes("`"));
+
+        if (isFenceOpen && fenceMatch) {
+            const fenceChar = fenceMatch[1][0];
+            const fenceLength = fenceMatch[1].length;
+            // Closing fence: same character, at least the same length, at
+            // line start, nothing but whitespace after it.
+            const closeRe = new RegExp(
+                `^ {0,3}[${fenceChar}]{${fenceLength},}\\s*$`,
+            );
+
+            const block: string[] = [line];
+            i++;
+            // An unterminated fence runs to EOF.
+            while (i < lines.length) {
+                block.push(lines[i]);
+                i++;
+                if (closeRe.test(block[block.length - 1])) {
+                    break;
+                }
+            }
+            out.push(makeToken(block.join("\n")));
+            continue;
+        }
+
+        // Indented code block (pragmatic CommonMark subset): consecutive
+        // lines indented >= 4 spaces (or a tab), starting after a blank line
+        // (or at the start of the document). Interior blank lines are part
+        // of the block only when followed by another indented line.
+        const prevBlank = out.length === 0 || isBlank(out[out.length - 1]);
+        if (isIndentedCodeLine(line) && prevBlank) {
+            const block: string[] = [line];
+            i++;
+            while (i < lines.length) {
+                if (isIndentedCodeLine(lines[i])) {
+                    block.push(lines[i]);
+                    i++;
+                    continue;
+                }
+                if (isBlank(lines[i])) {
+                    let j = i;
+                    while (j < lines.length && isBlank(lines[j])) {
+                        j++;
+                    }
+                    if (j < lines.length && isIndentedCodeLine(lines[j])) {
+                        while (i < j) {
+                            block.push(lines[i]);
+                            i++;
+                        }
+                        continue;
+                    }
+                }
+                break;
+            }
+            out.push(makeToken(block.join("\n")));
+            continue;
+        }
+
+        out.push(line);
+        i++;
+    }
+
+    // HTML comments (well-formed <!-- ... -->, possibly spanning lines).
+    // Comments inside code regions are already hidden behind tokens, and
+    // tokens themselves contain no "<!--", so this is safe on the joined
+    // text.
+    const masked = out
+        .join("\n")
+        .replace(/<!--[\s\S]*?-->/g, (match) => makeToken(match));
+
+    const tokenRe = new RegExp(`${base}(\\d+)${base}`, "g");
+    const unmask = (input: string): string =>
+        // Stored originals cannot contain the token base, so one pass is
+        // enough (no nested tokens can survive in the output).
+        input.replace(tokenRe, (_match, index) => store[Number(index)]);
+
+    return { maskedText: masked, unmask };
+}

--- a/src/utils/toc.test.ts
+++ b/src/utils/toc.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { extractTableOfContents } from "./toc";
+
+describe("extractTableOfContents", () => {
+    it("extracts real headings and skips the level-1 title", () => {
+        const markdown = `# Title
+
+## Section One
+
+### Subsection
+
+## Section Two
+`;
+
+        const entries = extractTableOfContents(markdown);
+
+        expect(entries).toEqual([
+            { id: "section-one", level: 2, title: "Section One" },
+            { id: "subsection", level: 3, title: "Subsection" },
+            { id: "section-two", level: 2, title: "Section Two" },
+        ]);
+    });
+
+    it("ignores heading-like lines inside fenced code blocks", () => {
+        const markdown = `# Title
+
+## Real Section
+
+\`\`\`bash
+# Install
+## Configure
+\`\`\`
+
+## Another Section
+`;
+
+        const entries = extractTableOfContents(markdown);
+
+        expect(entries.map((entry) => entry.title)).toEqual([
+            "Real Section",
+            "Another Section",
+        ]);
+    });
+
+    it("ignores heading-like lines inside tilde fences, indented code, and comments", () => {
+        const markdown = [
+            "# Title",
+            "",
+            "## Real Section",
+            "",
+            "~~~text",
+            "## Tilde Fake",
+            "~~~",
+            "",
+            "    ## Indented Fake",
+            "",
+            "<!-- ## Commented Fake -->",
+            "",
+            "### Real Subsection",
+            "",
+        ].join("\n");
+
+        const entries = extractTableOfContents(markdown);
+
+        expect(entries.map((entry) => entry.title)).toEqual([
+            "Real Section",
+            "Real Subsection",
+        ]);
+    });
+});

--- a/src/utils/toc.ts
+++ b/src/utils/toc.ts
@@ -1,3 +1,5 @@
+import { maskProtectedRegions } from "./markdownMasking";
+
 export interface TocEntry {
     id: string;
     level: number;
@@ -19,7 +21,11 @@ export function extractTableOfContents(markdownContent: string): TocEntry[] {
     const pattern = /^#+ (.*)$/gm;
     let match;
 
-    while ((match = pattern.exec(markdownContent)) !== null) {
+    // Mask code blocks and HTML comments so that `#` lines inside them are
+    // never mistaken for headings.
+    const { maskedText } = maskProtectedRegions(markdownContent);
+
+    while ((match = pattern.exec(maskedText)) !== null) {
         const [fullMatch, title] = match;
         const level = fullMatch.match(/^#+/)?.[0].length || 0;
         if (level === 1) continue;


### PR DESCRIPTION
## Problem

`MarkdownProcessor` scanned raw markdown with regexes without neutralizing code regions first, and split into sections BEFORE masking code. Verified bug classes:

1. **Section splitting destroys fences.** `splitIntoSections()` ran on the raw document, so a fenced code block containing a line starting with `## ` was split into two sections — the fence broke, the code rendered as prose, and labels inside code were processed.
2. **Non-line-aware fence extractor.** The per-section `/```[\s\S]*?```/g` extractor treated any triple-backtick run as a fence opener, so a stray/inline ``` ``` `` in prose mis-anchored it and paired with a later real fence, exposing code to the scanners.
3. **Indented code blocks never masked.** `$$\begin{equation}\label{...}` inside a 4-space-indented code block entered `equationMapping`.
4. **HTML comments scanned.** `<!-- <blockquote id=...> -->` created ghost `blockquoteMapping` entries and incremented the theorem/definition counters, shifting numbers of real blockquotes.
5. **Hard `$$\n` requirement.** The equation pattern required a literal `$$` + newline, so single-line `$$\begin{equation}...\end{equation}$$` rendered fine in KaTeX but was never mapped — broken `\eqref`/`\ref`.
6. **TOC and heading numbering.** `extractTableOfContents` (`/^#+ (.*)$/gm`) and `addHeadingNumbersToSections` matched `#` lines inside fenced code, producing bogus TOC entries and numbering code comments.

## Solution

New shared utility **`src/utils/markdownMasking.ts`** (`maskProtectedRegions`) masks all protected regions at the **document level**, before any other processing:

- **Fenced code blocks**, line-anchored per CommonMark: opening fence of 3+ backticks or tildes at line start (≤3 spaces indent) with optional info string (backtick fences reject info strings containing backticks); closing fence of the same character and at least the same length at line start; an unterminated fence runs to EOF.
- **Indented code blocks** (pragmatic CommonMark subset): consecutive lines indented ≥4 spaces (or tab) preceded by a blank line, including interior blank lines followed by more indented code.
- **HTML comments** (`<!-- ... -->`, multi-line).

Each region is replaced by a collision-proof placeholder (`NOTIEMASK<i>NOTIEMASK`, base grown until absent from the source; no `#`, no backticks, survives section splitting, inert to all later regexes).

`MarkdownProcessor.process()` now: mask → split into sections → scan equations/blockquotes per masked section → number headings (masked) → **unmask** each section (original text restored verbatim, including inside `equationString`/`blockquoteContent` mapping values). The old per-section `extractCodeBlocks`/`reinsertCodeBlocks` pass is removed — masking supersedes it. `wrapInDiv` still wraps sections `i > 0` only.

`toc.ts` applies the same shared masking before its heading scan, so headings inside restored code in the final `markdownContent` are ignored.

The equation pattern is relaxed from a literal `$$\n` to `\$\$\s*` (and drops the `\n` requirement before `\end`), so both multi-line and single-line environments are matched. Numbering semantics for previously-working forms are unchanged (verified by the untouched pre-existing tests).

## Tests

All existing tests pass **unmodified** (`MarkdownProcessor.test.ts`, `Notie.test.tsx`, `TikZ.test.tsx`) — 48/48 across 10 files. New coverage:

- `MarkdownProcessor.test.ts` — new `describe("MarkdownProcessor document-level masking")` block:
  - fenced block containing `## comment` → section count unchanged, fence intact, no mapping pollution
  - `\label` / `<blockquote id=...>` inside a fence → mappings empty
  - indented code block with `\label` → mapping empty, content restored verbatim
  - stray line-start ``` ``` `` (unterminated fence to EOF) → label not mapped, prose preserved
  - stray *inline* ``` ``` `` mid-line → not a fence; real equation mapped, label in the following real fence not mapped
  - HTML comment containing a blockquote → no ghost entry, counters unaffected (following real theorem numbered `1.1`)
  - single-line `$$\begin{equation}\label{eq:a}...\end{equation}$$` → mapped; mixed single/multi-line documents numbered in order (`1.1`, `1.2`)
  - `numberedHeading`: headings inside fences untouched, real headings numbered correctly
  - round-trip: complex document (backtick fence + tilde fence + indented code + comment + equations + blockquotes) → all original code/comment content verbatim in output; `markdownContent === markdownSections.join("")`
- New `src/utils/toc.test.ts`: real headings extracted; heading-like lines inside backtick fences, tilde fences, indented code, and HTML comments excluded from the TOC.

Also sanity-checked against the rich `src/dev/test.md` fixture: `# random data` inside the matplotlib fence no longer appears in the TOC, all fences round-trip byte-identical, and section/mapping outputs are as expected.

`npm test` ✔ `npm run lint` ✔ `npm run build` ✔ `npx prettier --check` on all changed files ✔ (rebased onto latest `agent-orchestra` after #56–#61; no lockfile changes).

## Risk

Highest-risk refactor of the session: it changes the order of the core processing pipeline. Mitigations:

- The bar was **no behavior change for well-formed documents**; all pre-existing tests pass without modification, and the equation-numbering semantics are exercised by the untouched fixture tests.
- The one intentional behavior change beyond bug fixes: a stray line-start ``` ``` `` in prose now opens an unterminated fence to EOF (CommonMark behavior, and what react-markdown renders anyway) instead of pairing with a later fence's opener — strictly closer to how the document actually renders.
- Indented-code masking is deliberately conservative (requires a preceding blank line), so 4-space-indented continuation lines inside lists/paragraphs are far less likely to be misclassified; even when a region is masked, unmasking restores it byte-identically, so the failure mode is limited to scanning/numbering, never content loss.
- Placeholder tokens are collision-proof by construction (base grown until absent from the source document).

🤖 Generated with [Claude Code](https://claude.com/claude-code)