### PR TITLE
perf: cache shiki highlight results for static code blocks (NOTIE-007)

### DIFF
--- a/src/components/StaticCodeBlock.tsx
+++ b/src/components/StaticCodeBlock.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useState } from "react";
-import type { BundledTheme } from "shiki";
 import { Pane } from "evergreen-ui";
 import CodeHeader from "./CodeHeader";
 import styles from "../styles/Notie.module.css";
-import { getHighlighter, resolveLanguage } from "../utils/shikiHighlighter";
+import { highlightWithCache } from "../utils/shikiHighlighter";
 
 function escapeHtml(s: string) {
     return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -24,19 +23,14 @@ const StaticCodeBlock = ({
 
     useEffect(() => {
         let cancelled = false;
-        getHighlighter().then((highlighter) => {
-            if (cancelled) return;
-            try {
-                setHtml(
-                    highlighter.codeToHtml(code, {
-                        lang: resolveLanguage(language),
-                        theme: theme as BundledTheme,
-                    }),
-                );
-            } catch {
+        highlightWithCache(code, language, theme)
+            .then((highlighted) => {
+                if (cancelled) return;
+                setHtml(highlighted);
+            })
+            .catch(() => {
                 // keep escaped fallback
-            }
-        });
+            });
         return () => {
             cancelled = true;
         };

--- a/src/utils/shikiHighlighter.test.ts
+++ b/src/utils/shikiHighlighter.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const codeToHtml = vi.fn(
+    (code: string, options: { lang: string; theme: string }) =>
+        `<pre data-theme="${options.theme}" data-lang="${options.lang}">${code}</pre>`,
+);
+
+vi.mock("shiki/core", () => ({
+    createHighlighterCore: vi.fn(async () => ({ codeToHtml })),
+}));
+
+vi.mock("shiki/engine/javascript", () => ({
+    createJavaScriptRegexEngine: vi.fn(() => ({})),
+}));
+
+import {
+    __configureHighlightCacheForTests,
+    highlightWithCache,
+} from "./shikiHighlighter";
+
+describe("highlightWithCache", () => {
+    beforeEach(() => {
+        __configureHighlightCacheForTests();
+        codeToHtml.mockClear();
+    });
+
+    it("only calls the underlying highlighter once for identical inputs", async () => {
+        const first = await highlightWithCache(
+            "print('hi')",
+            "python",
+            "github-dark",
+        );
+        const second = await highlightWithCache(
+            "print('hi')",
+            "python",
+            "github-dark",
+        );
+
+        expect(first).toBe(second);
+        expect(codeToHtml).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-highlights when the theme differs", async () => {
+        await highlightWithCache("print('hi')", "python", "github-dark");
+        await highlightWithCache("print('hi')", "python", "github-light");
+
+        expect(codeToHtml).toHaveBeenCalledTimes(2);
+    });
+
+    it("re-highlights when the language differs", async () => {
+        await highlightWithCache("x", "python", "github-dark");
+        await highlightWithCache("x", "javascript", "github-dark");
+
+        expect(codeToHtml).toHaveBeenCalledTimes(2);
+    });
+
+    it("re-highlights when the code differs", async () => {
+        await highlightWithCache("a", "python", "github-dark");
+        await highlightWithCache("b", "python", "github-dark");
+
+        expect(codeToHtml).toHaveBeenCalledTimes(2);
+    });
+
+    it("evicts the oldest entry when the cap is exceeded", async () => {
+        __configureHighlightCacheForTests(2);
+
+        await highlightWithCache("one", "python", "github-dark");
+        await highlightWithCache("two", "python", "github-dark");
+        await highlightWithCache("three", "python", "github-dark");
+        expect(codeToHtml).toHaveBeenCalledTimes(3);
+
+        // "two" and "three" are still cached...
+        await highlightWithCache("two", "python", "github-dark");
+        await highlightWithCache("three", "python", "github-dark");
+        expect(codeToHtml).toHaveBeenCalledTimes(3);
+
+        // ...but "one" was evicted and must be re-highlighted.
+        await highlightWithCache("one", "python", "github-dark");
+        expect(codeToHtml).toHaveBeenCalledTimes(4);
+    });
+
+    it("refreshes recency on cache hits (LRU-ish eviction)", async () => {
+        __configureHighlightCacheForTests(2);
+
+        await highlightWithCache("one", "python", "github-dark");
+        await highlightWithCache("two", "python", "github-dark");
+        // Touch "one" so "two" becomes the oldest entry.
+        await highlightWithCache("one", "python", "github-dark");
+        await highlightWithCache("three", "python", "github-dark");
+        expect(codeToHtml).toHaveBeenCalledTimes(3);
+
+        // "one" survived the eviction; "two" did not.
+        await highlightWithCache("one", "python", "github-dark");
+        expect(codeToHtml).toHaveBeenCalledTimes(3);
+        await highlightWithCache("two", "python", "github-dark");
+        expect(codeToHtml).toHaveBeenCalledTimes(4);
+    });
+
+    it("does not cache more entries than the cap", async () => {
+        __configureHighlightCacheForTests(3);
+
+        for (let i = 0; i < 10; i++) {
+            await highlightWithCache(`snippet-${i}`, "python", "github-dark");
+        }
+        expect(codeToHtml).toHaveBeenCalledTimes(10);
+
+        // Only the 3 most recent entries are cached.
+        await highlightWithCache("snippet-9", "python", "github-dark");
+        await highlightWithCache("snippet-8", "python", "github-dark");
+        await highlightWithCache("snippet-7", "python", "github-dark");
+        expect(codeToHtml).toHaveBeenCalledTimes(10);
+
+        await highlightWithCache("snippet-6", "python", "github-dark");
+        expect(codeToHtml).toHaveBeenCalledTimes(11);
+    });
+});

--- a/src/utils/shikiHighlighter.ts
+++ b/src/utils/shikiHighlighter.ts
@@ -45,6 +45,54 @@ export const PRELOADED_THEMES: BundledTheme[] = [
 
 let highlighterPromise: ReturnType<typeof createHighlighterCore> | null = null;
 
+const DEFAULT_HIGHLIGHT_CACHE_CAP = 200;
+
+let highlightCacheCap = DEFAULT_HIGHLIGHT_CACHE_CAP;
+
+// Bounded LRU-ish cache of highlight results. Map iteration order is
+// insertion order; hits are re-inserted so the oldest entry is evicted first.
+const highlightCache = new Map<string, string>();
+
+/** Test hook: override the cache capacity and clear the cache. */
+export function __configureHighlightCacheForTests(
+    cap: number = DEFAULT_HIGHLIGHT_CACHE_CAP,
+) {
+    highlightCacheCap = cap;
+    highlightCache.clear();
+}
+
+/**
+ * Highlight `code`, memoizing the resulting HTML per (theme, lang, code).
+ * Static code blocks remount on section re-renders with identical inputs,
+ * so caching avoids repeating the dominant codeToHtml cost.
+ */
+export async function highlightWithCache(
+    code: string,
+    lang: string,
+    theme: string,
+): Promise<string> {
+    const key = `${theme}|${lang}|${code}`;
+    const cached = highlightCache.get(key);
+    if (cached !== undefined) {
+        // Refresh recency: move the entry to the end of iteration order.
+        highlightCache.delete(key);
+        highlightCache.set(key, cached);
+        return cached;
+    }
+    const highlighter = await getHighlighter();
+    const html = highlighter.codeToHtml(code, {
+        lang: resolveLanguage(lang),
+        theme: theme as BundledTheme,
+    });
+    highlightCache.set(key, html);
+    while (highlightCache.size > highlightCacheCap) {
+        const oldest = highlightCache.keys().next().value;
+        if (oldest === undefined) break;
+        highlightCache.delete(oldest);
+    }
+    return html;
+}
+
 export function getHighlighter() {
     if (!highlighterPromise) {
         highlighterPromise = createHighlighterCore({


### PR DESCRIPTION
## Problem

`StaticCodeBlock` re-runs `highlighter.codeToHtml` on every mount. Section re-renders remount static code blocks with identical `(code, language, theme)` inputs, so the dominant highlight cost is redone for content that has not changed.

## Solution

- Add a module-level bounded LRU-ish cache in `src/utils/shikiHighlighter.ts`: `Map<string, string>` keyed by `${theme}|${lang}|${code}`, capped at 200 entries. Eviction removes the oldest entry via Map insertion order; cache hits are re-inserted to refresh recency.
- Expose it as `highlightWithCache(code, lang, theme): Promise<string>` (plus a `__configureHighlightCacheForTests` hook to set the cap and clear the cache in tests).
- `StaticCodeBlock` now calls `highlightWithCache` from its effect; on a cache hit the HTML resolves without a highlighter roundtrip. Error handling keeps the escaped-HTML fallback.
- `CodeBlock` (editable) is intentionally left uncached — its code changes on every keystroke, so caching would only churn the map.

## Tests

New `src/utils/shikiHighlighter.test.ts` mocks `shiki/core` with a counted `codeToHtml`:
- two sequential calls with identical inputs → 1 underlying call
- different theme / language / code → new underlying call
- cap eviction: oldest entry evicted past the cap; recency refresh on hits keeps touched entries alive; many keys never exceed the cap

`npm test` (74 passed), `npm run lint`, `npm run build`, `npx prettier --check .` all pass.

## Risk

Low. Cache is bounded (200 entries) so memory growth is capped; keys include theme and language so theme switches cannot serve stale HTML. Behavior of `StaticCodeBlock` is unchanged apart from skipping redundant highlighting; editable `CodeBlock` path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)