### PR TITLE
feat: theme-aware blockquote styling and preview cards; referenceable proof/note/important (NOTIE-031/036)

### DIFF
--- a/src/components/BlockquoteReference.tsx
+++ b/src/components/BlockquoteReference.tsx
@@ -19,32 +19,30 @@ interface BlockquoteStyle {
     labelColor: string;
 }
 
-const BLOCKQUOTE_STYLES: Record<string, BlockquoteStyle> = {
-    definition: {
-        background: "rgba(174, 247, 126, 0.2)",
-        labelColor: "#31dd2e",
-    },
-    proof: { background: "rgba(174, 247, 126, 0.2)", labelColor: "#31dd2e" },
-    theorem: { background: "rgba(126, 174, 247, 0.2)", labelColor: "#486bd5" },
-    lemma: { background: "rgba(126, 174, 247, 0.2)", labelColor: "#486bd5" },
-    algorithm: {
-        background: "rgba(126, 174, 247, 0.2)",
-        labelColor: "#486bd5",
-    },
-    problem: { background: "rgba(126, 174, 247, 0.2)", labelColor: "#486bd5" },
-    important: {
-        background: "rgba(247, 126, 126, 0.2)",
-        labelColor: "#dd2e2e",
-    },
-    note: {
-        background: "rgb(255 253 0 / 19%)",
-        labelColor: "lch(86 109.24 91.22)",
-    },
-};
+// The preview card shares the theme-aware CSS variables that style
+// blockquotes in notie-global.css (set per appearance in useNotieConfig).
+// Lemmas share the theorem colors, mirroring the blockquote CSS rules.
+const blockquoteStyleFor = (blockquoteType: string): BlockquoteStyle => {
+    const knownTypes = [
+        "definition",
+        "proof",
+        "equation",
+        "theorem",
+        "lemma",
+        "algorithm",
+        "problem",
+        "important",
+        "note",
+    ];
+    let variableType = knownTypes.includes(blockquoteType)
+        ? blockquoteType
+        : "theorem";
+    if (variableType === "lemma") variableType = "theorem";
 
-const DEFAULT_STYLE: BlockquoteStyle = {
-    background: "rgba(126, 174, 247, 0.2)",
-    labelColor: "#486bd5",
+    return {
+        background: `var(--blog-bq-${variableType}-bg, rgba(126, 174, 247, 0.2))`,
+        labelColor: `var(--blog-bq-${variableType}-label, #486bd5)`,
+    };
 };
 
 const BlockquoteReference = ({
@@ -112,7 +110,7 @@ const BlockquoteCard = ({
     equationMapping: EquationMapping;
     previewEquations?: boolean;
 }) => {
-    const style = BLOCKQUOTE_STYLES[blockquoteType] ?? DEFAULT_STYLE;
+    const style = blockquoteStyleFor(blockquoteType);
     const strippedContent = content.replace(/\\label\{[^}]*\}/g, "");
     const components = useMemo(
         () => ({
@@ -148,7 +146,13 @@ const BlockquoteCard = ({
     return (
         <div
             style={{
-                background: style.background,
+                // Layer the translucent type tint over the theme background
+                // so the card matches in-page blockquotes in both light and
+                // dark appearances (the tooltip surface color never shows
+                // through).
+                backgroundColor: "var(--blog-background-color)",
+                backgroundImage: `linear-gradient(${style.background}, ${style.background})`,
+                color: "var(--blog-text-color)",
                 borderRadius: "5px",
                 paddingLeft: "0.8rem",
                 paddingRight: "0.8rem",

--- a/src/components/Notie.test.tsx
+++ b/src/components/Notie.test.tsx
@@ -149,6 +149,92 @@ See [Algorithm](#bqref-alg:critic-target).
         expect(container.querySelector(".katex-error")).not.toBeInTheDocument();
     });
 
+    it("resolves references to proof and note blockquotes with numbers", () => {
+        render(
+            <Notie
+                markdown={`# Demo
+
+## First Section
+
+<blockquote class="proof" id="proof:main">
+Proof body.
+</blockquote>
+
+<blockquote class="note" id="note:main">
+Note body.
+</blockquote>
+
+See [proof](#bqref-proof:main) and [note](#bqref-note:main).
+`}
+            />,
+        );
+
+        const proofReference = screen
+            .getAllByRole("link")
+            .find((link) => link.getAttribute("href") === "#proof:main");
+        expect(proofReference).toHaveTextContent("Proof 1.1");
+
+        const noteReference = screen
+            .getAllByRole("link")
+            .find((link) => link.getAttribute("href") === "#note:main");
+        expect(noteReference).toHaveTextContent("Note 1.1");
+    });
+
+    it("sets dark blockquote CSS variables and themes preview cards in dark mode", async () => {
+        const { baseElement } = render(
+            <Notie
+                markdown={`# Demo
+
+## First Section
+
+<blockquote class="definition" id="def:dark">
+Dark definition.
+</blockquote>
+
+See [definition](#bqref-def:dark).
+`}
+                theme="default dark"
+            />,
+        );
+
+        // Dark appearance swaps the blockquote variables on the root element.
+        const rootStyle = document.documentElement.style;
+        expect(rootStyle.getPropertyValue("--blog-bq-definition-bg")).toBe(
+            "rgba(120, 220, 80, 0.14)",
+        );
+        expect(rootStyle.getPropertyValue("--blog-bq-definition-label")).toBe(
+            "#6ee76a",
+        );
+        expect(rootStyle.getPropertyValue("--blog-bq-shadow")).toContain(
+            "rgba(0, 0, 0, 0.5)",
+        );
+
+        // The preview card consumes the same variables and inherits the
+        // theme text color, so its content stays readable in dark mode.
+        const definitionReference = screen.getByRole("link", {
+            name: "Definition 1.1",
+        });
+        fireEvent.mouseEnter(definitionReference);
+
+        await waitFor(() => {
+            expect(
+                within(baseElement).getByText("Definition 1.1."),
+            ).toBeInTheDocument();
+        });
+
+        const card = within(baseElement)
+            .getByText("Definition 1.1.")
+            .closest("div") as HTMLElement;
+        expect(card.style.backgroundImage).toContain(
+            "var(--blog-bq-definition-bg",
+        );
+        expect(card.style.color).toBe("var(--blog-text-color)");
+        const cardLabel = within(baseElement).getByText("Definition 1.1.");
+        expect(cardLabel.style.color).toContain(
+            "var(--blog-bq-definition-label",
+        );
+    });
+
     it("renders large notes progressively while preserving TOC navigation", async () => {
         render(
             <Notie

--- a/src/styles/notie-global.css
+++ b/src/styles/notie-global.css
@@ -56,14 +56,36 @@
 }
 
 /* Temp Global Blockquote Styles */
+
+/* Theme-aware blockquote colors. These defaults match the light appearance;
+   useNotieConfig overrides them per theme appearance (light/dark). */
+:root {
+    --blog-bq-definition-bg: rgba(174, 247, 126, 0.2);
+    --blog-bq-definition-label: #31dd2e;
+    --blog-bq-proof-bg: rgba(174, 247, 126, 0.2);
+    --blog-bq-proof-label: #31dd2e;
+    --blog-bq-equation-bg: rgba(126, 174, 247, 0.2);
+    --blog-bq-equation-label: #486bd5;
+    --blog-bq-theorem-bg: rgba(126, 174, 247, 0.2);
+    --blog-bq-theorem-label: #486bd5;
+    --blog-bq-algorithm-bg: rgba(126, 174, 247, 0.2);
+    --blog-bq-algorithm-label: #486bd5;
+    --blog-bq-problem-bg: rgba(126, 174, 247, 0.2);
+    --blog-bq-problem-label: #486bd5;
+    --blog-bq-important-bg: rgba(247, 126, 126, 0.2);
+    --blog-bq-important-label: #dd2e2e;
+    --blog-bq-note-bg: rgb(255 253 0 / 19%);
+    --blog-bq-note-label: lch(86 109.24 91.22);
+    --blog-bq-shadow: 0 1px 2px rgba(0, 0, 0, 0.12),
+        0 3px 10px rgba(0, 0, 0, 0.08);
+}
+
 blockquote {
     margin-block-start: 0;
     margin-inline-start: 0;
     display: block;
     border-radius: 5px;
-    box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.12),
-        0 3px 10px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--blog-bq-shadow);
     padding-left: 0.8rem;
     padding-right: 0.8rem;
     padding-bottom: 0.9em;
@@ -88,101 +110,101 @@ blockquote::before {
 
 /* Definition */
 blockquote.definition::before {
-    color: #31dd2e;
+    color: var(--blog-bq-definition-label);
     content: "Definition";
 }
 
 blockquote.definition {
-    background: rgba(174, 247, 126, 0.2);
+    background: var(--blog-bq-definition-bg);
     border-left: 5px solid #31dd2e;
 }
 
 /* Proof */
 blockquote.proof::before {
-    color: #31dd2e;
+    color: var(--blog-bq-proof-label);
     content: "Proof";
 }
 
 blockquote.proof {
-    background: rgba(174, 247, 126, 0.2);
+    background: var(--blog-bq-proof-bg);
     border-left: 5px solid #31dd2e;
 }
 
 /* Equation */
 blockquote.equation::before {
-    color: #486bd5;
+    color: var(--blog-bq-equation-label);
     content: "Equation";
 }
 
 blockquote.equation {
-    background: rgba(126, 174, 247, 0.2);
+    background: var(--blog-bq-equation-bg);
     border-left: 5px solid #486bd5;
     padding-bottom: 0.1em;
 }
 
 /* Theorem */
 blockquote.theorem::before {
-    color: #486bd5;
+    color: var(--blog-bq-theorem-label);
     content: "Theorem";
 }
 
 blockquote.theorem {
-    background: rgba(126, 174, 247, 0.2);
+    background: var(--blog-bq-theorem-bg);
     border-left: 5px solid #486bd5;
 }
 
 /* Lemma */
 blockquote.lemma::before {
-    color: #486bd5;
+    color: var(--blog-bq-theorem-label);
     content: "Lemma";
 }
 
 blockquote.lemma {
-    background: rgba(126, 174, 247, 0.2);
+    background: var(--blog-bq-theorem-bg);
     border-left: 5px solid #486bd5;
 }
 
 /* Algorithm */
 blockquote.algorithm::before {
-    color: #486bd5;
+    color: var(--blog-bq-algorithm-label);
     content: "Algorithm";
 }
 
 blockquote.algorithm {
-    background: rgba(126, 174, 247, 0.2);
+    background: var(--blog-bq-algorithm-bg);
     border-left: 5px solid #486bd5;
 }
 
 /* Problem */
 blockquote.problem::before {
-    color: #486bd5;
+    color: var(--blog-bq-problem-label);
     content: "Problem";
 }
 
 blockquote.problem {
-    background: rgba(126, 174, 247, 0.2);
+    background: var(--blog-bq-problem-bg);
     border-left: 5px solid #486bd5;
 }
 
 /* Important */
 blockquote.important::before {
-    color: #dd2e2e;
+    color: var(--blog-bq-important-label);
     content: "Important";
 }
 
 blockquote.important {
-    background: rgba(247, 126, 126, 0.2);
+    background: var(--blog-bq-important-bg);
     border-left: 5px solid #dd2e2e;
 }
 
 /* Note */
 blockquote.note::before {
-    color: lch(86 109.24 91.22);
+    color: var(--blog-bq-note-label);
     content: "Note";
 }
 
 blockquote.note {
-    background: rgb(255 253 0 / 19%);
+    background: var(--blog-bq-note-bg);
     border-left: 5px solid #ffea00;
 }
 
@@ -192,9 +214,7 @@ blockquote.note {
     margin-inline-start: 0;
     display: block;
     border-radius: 5px;
-    box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.12),
-        0 3px 10px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--blog-bq-shadow);
     padding: 0.9rem 0.8rem;
     margin: 16px auto;
     position: relative;

--- a/src/utils/MarkdownProcessor.test.ts
+++ b/src/utils/MarkdownProcessor.test.ts
@@ -84,6 +84,71 @@ See $\\eqref{eq:first}$ and [definition](#bqref-def:first).
         });
     });
 
+    it("maps proof, note, and important blockquotes with independent counters", () => {
+        const markdown = `# Title
+
+## Section One
+
+<blockquote class="proof" id="proof:first">
+Proof body.
+</blockquote>
+
+<blockquote class="note" id="note:first">
+Note body.
+</blockquote>
+
+<blockquote class="proof" id="proof:second">
+Second proof body.
+</blockquote>
+
+<blockquote class="important" id="imp:first">
+Important body.
+</blockquote>
+
+<blockquote class="theorem" id="thm:first">
+Theorem body.
+</blockquote>
+
+<blockquote class="lemma" id="lem:first">
+Lemma body.
+</blockquote>
+
+See [proof](#bqref-proof:first) and [note](#bqref-note:first).
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        // proof/note/important each keep their own counter...
+        expect(result.blockquoteMapping["proof:first"]).toEqual({
+            blockquoteNumber: "1.1",
+            blockquoteType: "proof",
+            blockquoteContent: "Proof body.",
+        });
+        expect(result.blockquoteMapping["proof:second"]).toEqual({
+            blockquoteNumber: "1.2",
+            blockquoteType: "proof",
+            blockquoteContent: "Second proof body.",
+        });
+        expect(result.blockquoteMapping["note:first"]).toEqual({
+            blockquoteNumber: "1.1",
+            blockquoteType: "note",
+            blockquoteContent: "Note body.",
+        });
+        expect(result.blockquoteMapping["imp:first"]).toEqual({
+            blockquoteNumber: "1.1",
+            blockquoteType: "important",
+            blockquoteContent: "Important body.",
+        });
+
+        // ...while theorem and lemma still share a counter.
+        expect(result.blockquoteMapping["thm:first"].blockquoteNumber).toBe(
+            "1.1",
+        );
+        expect(result.blockquoteMapping["lem:first"].blockquoteNumber).toBe(
+            "1.2",
+        );
+    });
+
     it("does not scan labels inside fenced code blocks", () => {
         const errorSpy = vi
             .spyOn(console, "error")

--- a/src/utils/MarkdownProcessor.ts
+++ b/src/utils/MarkdownProcessor.ts
@@ -103,6 +103,9 @@ export class MarkdownProcessor {
             "lemma",
             "algorithm",
             "problem",
+            "proof",
+            "note",
+            "important",
         ];
         const counts: Record<string, number> = {};
 

--- a/src/utils/useNotieConfig.ts
+++ b/src/utils/useNotieConfig.ts
@@ -143,6 +143,48 @@ const defaultTheme: FullTheme = {
     tocMarker: true,
 };
 
+// Blockquote colors per theme appearance. The light values match the
+// original hardcoded colors in notie-global.css exactly; the dark values
+// keep each type's hue but use darker translucent backgrounds and label
+// colors that stay readable on dark page backgrounds. Text color inside
+// blockquotes inherits --blog-text-color.
+interface BlockquotePalette {
+    types: Record<string, { bg: string; label: string }>;
+    shadow: string;
+}
+
+const blockquotePalettes: Record<"light" | "dark", BlockquotePalette> = {
+    light: {
+        types: {
+            definition: { bg: "rgba(174, 247, 126, 0.2)", label: "#31dd2e" },
+            proof: { bg: "rgba(174, 247, 126, 0.2)", label: "#31dd2e" },
+            equation: { bg: "rgba(126, 174, 247, 0.2)", label: "#486bd5" },
+            theorem: { bg: "rgba(126, 174, 247, 0.2)", label: "#486bd5" },
+            algorithm: { bg: "rgba(126, 174, 247, 0.2)", label: "#486bd5" },
+            problem: { bg: "rgba(126, 174, 247, 0.2)", label: "#486bd5" },
+            important: { bg: "rgba(247, 126, 126, 0.2)", label: "#dd2e2e" },
+            note: {
+                bg: "rgb(255 253 0 / 19%)",
+                label: "lch(86 109.24 91.22)",
+            },
+        },
+        shadow: "0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08)",
+    },
+    dark: {
+        types: {
+            definition: { bg: "rgba(120, 220, 80, 0.14)", label: "#6ee76a" },
+            proof: { bg: "rgba(120, 220, 80, 0.14)", label: "#6ee76a" },
+            equation: { bg: "rgba(110, 155, 240, 0.16)", label: "#93aef2" },
+            theorem: { bg: "rgba(110, 155, 240, 0.16)", label: "#93aef2" },
+            algorithm: { bg: "rgba(110, 155, 240, 0.16)", label: "#93aef2" },
+            problem: { bg: "rgba(110, 155, 240, 0.16)", label: "#93aef2" },
+            important: { bg: "rgba(240, 100, 100, 0.16)", label: "#f57171" },
+            note: { bg: "rgba(255, 234, 0, 0.12)", label: "#ffe14d" },
+        },
+        shadow: "0 1px 2px rgba(0, 0, 0, 0.5), 0 3px 10px rgba(0, 0, 0, 0.35)",
+    },
+};
+
 const defaultNotieConfig: FullNotieConfig = {
     showTableOfContents: true,
     previewEquations: true,
@@ -298,6 +340,17 @@ export function useNotieConfig(
             "--blog-toc-marker",
             mergedConfig.theme.tocMarker ? "true" : "false",
         );
+
+        // Theme-aware blockquote colors (backgrounds, labels, shadow).
+        const blockquotePalette =
+            blockquotePalettes[
+                mergedConfig.theme.appearance === "dark" ? "dark" : "light"
+            ];
+        for (const [type, colors] of Object.entries(blockquotePalette.types)) {
+            root.style.setProperty(`--blog-bq-${type}-bg`, colors.bg);
+            root.style.setProperty(`--blog-bq-${type}-label`, colors.label);
+        }
+        root.style.setProperty("--blog-bq-shadow", blockquotePalette.shadow);
 
         // Handle custom fonts: append a <link> for each configured font URL
         // (main content and TOC) and remove all of them on cleanup.


### PR DESCRIPTION
## Problem

**NOTIE-031:** Blockquote styling in `notie-global.css` was hardcoded to light-mode colors (pale translucent backgrounds, light-mode label colors, light box-shadow) with no CSS variables, so dark themes rendered the exact same pale boxes. The preview card in `BlockquoteReference.tsx` duplicated those colors inline and never set a text color, producing unreadable pale-background/white-text (or invisible) cards in dark mode.

**NOTIE-036:** `MarkdownProcessor` only treated `definition/theorem/lemma/algorithm/problem` as referenceable, even though `proof`, `note`, and `important` blockquotes are fully styled. Referencing e.g. `<blockquote class="proof" id="proof:x">` via `#bqref-proof:x` silently failed with red error text.

## Solution

- Extracted all blockquote backgrounds, label colors, and the box-shadow into `--blog-bq-<type>-bg` / `--blog-bq-<type>-label` / `--blog-bq-shadow` custom properties. `:root` defaults in `notie-global.css` match the previous light values exactly — zero visual change for light themes.
- `useNotieConfig` sets the variables via the existing `root.style.setProperty` mechanism: light palette for `appearance: light`, and a dark palette (darker translucent backgrounds keeping each type's hue, brighter readable label colors, deeper shadow) for `appearance: dark` ("default dark", "Starlit Eclipse").
- The `BlockquoteCard` preview now consumes the same CSS variables (with light-value fallbacks), layers the translucent tint over `var(--blog-background-color)` so the tooltip surface never bleeds through, and explicitly sets `color: var(--blog-text-color)`.
- Added `proof", "note", "important` to `SUPPORTED` in `MarkdownProcessor`; each gets its own section-scoped counter, theorem+lemma keep their shared counter. Display labels ("Proof 1.1", "Note 1.1", …) come from the existing generic capitalization in `BlockquoteReference`. `Notie.tsx` (LaTeX-style DOM numbering effect) is intentionally untouched.

## Tests

- `MarkdownProcessor.test.ts`: new test mapping proof/note/important blockquotes with independent counters, verifying theorem+lemma still share a counter and references resolve with sensible numbers.
- `Notie.test.tsx`: new tests that (1) proof/note references resolve to "Proof 1.1" / "Note 1.1" links, and (2) rendering with `theme="default dark"` sets the dark `--blog-bq-definition-bg`/`-label`/`--blog-bq-shadow` values on `document.documentElement`, and the hovered preview card uses the CSS variables and `color: var(--blog-text-color)`.
- Full suite: 70/70 tests pass; `npm run lint`, `npm run build`, and `npx prettier --check .` all clean. No lockfile changes.

## Risk

UI change: dark-mode blockquotes and preview cards now use dark backgrounds/labels (light mode is pixel-identical to before). `proof`/`note`/`important` blockquotes with `id` attributes now enter the blockquote mapping — previously-broken references start resolving, and duplicate-id console errors can now fire for these types too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)