### PR TITLE
a11y: button labels, live copy announcement, reduced motion, focus-visible, TOC heading level (NOTIE-030/008)

### DIFF
--- a/src/components/CodeBlock.test.tsx
+++ b/src/components/CodeBlock.test.tsx
@@ -75,3 +75,45 @@ describe("CodeBlock", () => {
         });
     });
 });
+
+describe("CodeBlock accessibility", () => {
+    afterEach(() => {
+        restorePlatform();
+    });
+
+    it("exposes an accessible name on the reset button", () => {
+        render(
+            <CodeBlock
+                initialCode={'print("hello")'}
+                language="python"
+                theme="github-light"
+            />,
+        );
+
+        expect(
+            screen.getByRole("button", { name: /reset code/i }),
+        ).toBeInTheDocument();
+    });
+
+    it("exposes an accessible name on the run button and hides the decorative key icons", () => {
+        const { container } = render(
+            <CodeBlock
+                initialCode={'print("hello")'}
+                language="python"
+                theme="github-light"
+            />,
+        );
+
+        expect(
+            screen.getByRole("button", { name: /run code/i }),
+        ).toBeInTheDocument();
+
+        const hiddenIconGroup = container.querySelector(
+            'button [aria-hidden="true"]',
+        );
+        expect(hiddenIconGroup).not.toBeNull();
+        expect(hiddenIconGroup?.querySelectorAll("svg").length).toBeGreaterThan(
+            0,
+        );
+    });
+});

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -215,6 +215,7 @@ const CodeBlock = ({
                             appearance="minimal"
                             icon={ResetIcon}
                             intent="danger"
+                            aria-label="Reset code"
                             onClick={resetEditor}
                         />
                     </Pane>
@@ -224,6 +225,7 @@ const CodeBlock = ({
                             appearance="primary"
                             intent="success"
                             isLoading={isLoading}
+                            aria-label="Run code (Cmd/Ctrl+Enter)"
                             onClick={runCodeAsync}
                         >
                             <span
@@ -232,12 +234,20 @@ const CodeBlock = ({
                                     alignItems: "center",
                                 }}
                             >
-                                {isMac ? (
-                                    <KeyCommandIcon size={12} />
-                                ) : (
-                                    <KeyControlIcon size={12} />
-                                )}
-                                <KeyEnterIcon size={12} />
+                                <span
+                                    aria-hidden="true"
+                                    style={{
+                                        display: "inline-flex",
+                                        alignItems: "center",
+                                    }}
+                                >
+                                    {isMac ? (
+                                        <KeyCommandIcon size={12} />
+                                    ) : (
+                                        <KeyControlIcon size={12} />
+                                    )}
+                                    <KeyEnterIcon size={12} />
+                                </span>
                                 <span style={{ marginLeft: 4 }}>
                                     {"Run Code"}
                                 </span>

--- a/src/components/CodeHeader.test.tsx
+++ b/src/components/CodeHeader.test.tsx
@@ -55,6 +55,49 @@ describe("CodeHeader", () => {
         expect(screen.getByText("Copy Code")).toBeInTheDocument();
     });
 
+    it("announces 'Copied to clipboard' via an aria-live status region", async () => {
+        const writeText = vi.fn(() => Promise.resolve());
+        stubClipboard(writeText);
+
+        render(<CodeHeader language="python" code="print('hello')" />);
+
+        const status = screen.getByRole("status");
+        expect(status).toHaveAttribute("aria-live", "polite");
+        expect(status).toHaveTextContent("");
+
+        fireEvent.click(screen.getByRole("button", { name: /copy code/i }));
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(status).toHaveTextContent("Copied to clipboard");
+
+        act(() => {
+            vi.advanceTimersByTime(2000);
+        });
+
+        expect(status).toHaveTextContent("");
+    });
+
+    it("keeps a stable 'Copy code' accessible name while showing 'Copied!'", async () => {
+        const writeText = vi.fn(() => Promise.resolve());
+        stubClipboard(writeText);
+
+        render(<CodeHeader language="python" code="print('hello')" />);
+
+        fireEvent.click(screen.getByRole("button", { name: /copy code/i }));
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        // The visible label switches to "Copied!", but the accessible name
+        // stays stable via aria-label.
+        expect(
+            screen.getByRole("button", { name: /copy code/i }),
+        ).toBeInTheDocument();
+        expect(screen.getByText("Copied!")).toBeInTheDocument();
+    });
+
     it("does not show 'Copied!' when the clipboard write rejects", async () => {
         const writeText = vi.fn(() => Promise.reject(new Error("denied")));
         stubClipboard(writeText);

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -1,6 +1,7 @@
 import { Pane, Button, ClipboardIcon, TickCircleIcon } from "evergreen-ui";
 import { useEffect, useRef, useState } from "react";
 import styles from "../styles/Notie.module.css";
+import "../styles/notie-global.css";
 
 const CodeHeader = ({ language, code }: { language: string; code: string }) => {
     const [isCopied, setIsCopied] = useState(false);
@@ -73,10 +74,14 @@ const CodeHeader = ({ language, code }: { language: string; code: string }) => {
                 paddingY={1}
                 paddingX={8}
                 color="inherit"
+                aria-label="Copy code"
                 className={styles["copy-button"]}
             >
                 {isCopied ? "Copied!" : "Copy Code"}
             </Button>
+            <span role="status" aria-live="polite" className="sr-only">
+                {isCopied ? "Copied to clipboard" : ""}
+            </span>
         </Pane>
     );
 };

--- a/src/components/Notie.tsx
+++ b/src/components/Notie.tsx
@@ -217,7 +217,7 @@ const Notie: React.FC<NotieProps> = ({
                         <NoteToc
                             tocEntries={tocEntries}
                             activeId={activeId}
-                            config={config}
+                            tocTitle={config.tocTitle}
                             onNavigate={handleTocNavigate}
                         />
                     </Pane>

--- a/src/components/NotieToc.test.tsx
+++ b/src/components/NotieToc.test.tsx
@@ -1,10 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import { NotieConfig } from "../config/NotieConfig";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { TocEntry } from "../utils/toc";
 import NotieToc from "./NotieToc";
 
-const config: NotieConfig = { tocTitle: "Contents" };
+const tocTitle = "Contents";
 
 const tocEntries: TocEntry[] = [
     { id: "first-section", level: 2, title: "First Section" },
@@ -12,10 +11,46 @@ const tocEntries: TocEntry[] = [
     { id: "deep-section", level: 4, title: "Deep Section" },
 ];
 
+function stubMatchMedia(matches: boolean) {
+    vi.stubGlobal(
+        "matchMedia",
+        vi.fn((query: string) => ({
+            matches,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })),
+    );
+}
+
+const originalScrollTo = HTMLElement.prototype.scrollTo;
+
+function stubElementScrollTo() {
+    const scrollTo = vi.fn();
+    // The property is defined as writable (but not configurable) in the test
+    // setup, so replace it with plain assignment.
+    HTMLElement.prototype.scrollTo = scrollTo;
+    return scrollTo;
+}
+
 describe("NotieToc", () => {
+    afterEach(() => {
+        HTMLElement.prototype.scrollTo = originalScrollTo;
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
     it("renders the title and one link per entry", () => {
         render(
-            <NotieToc tocEntries={tocEntries} activeId="" config={config} />,
+            <NotieToc
+                tocEntries={tocEntries}
+                activeId=""
+                tocTitle={tocTitle}
+            />,
         );
 
         expect(
@@ -33,12 +68,28 @@ describe("NotieToc", () => {
         ]);
     });
 
+    it("renders the TOC title as an <h2>, not an <h1>", () => {
+        render(
+            <NotieToc
+                tocEntries={tocEntries}
+                activeId=""
+                tocTitle={tocTitle}
+            />,
+        );
+
+        const heading = screen.getByRole("heading", { name: "Contents" });
+        expect(heading.tagName).toBe("H2");
+        expect(
+            screen.queryByRole("heading", { level: 1 }),
+        ).not.toBeInTheDocument();
+    });
+
     it("applies the active class only to the active entry", () => {
         render(
             <NotieToc
                 tocEntries={tocEntries}
                 activeId="nested-section"
-                config={config}
+                tocTitle={tocTitle}
             />,
         );
 
@@ -59,7 +110,7 @@ describe("NotieToc", () => {
             <NotieToc
                 tocEntries={tocEntries}
                 activeId=""
-                config={config}
+                tocTitle={tocTitle}
                 onNavigate={onNavigate}
             />,
         );
@@ -75,7 +126,11 @@ describe("NotieToc", () => {
 
     it("indents entries proportionally to their heading level", () => {
         render(
-            <NotieToc tocEntries={tocEntries} activeId="" config={config} />,
+            <NotieToc
+                tocEntries={tocEntries}
+                activeId=""
+                tocTitle={tocTitle}
+            />,
         );
 
         const listItems = screen.getAllByRole("listitem");
@@ -84,5 +139,39 @@ describe("NotieToc", () => {
             "1em",
             "2em",
         ]);
+    });
+
+    it("scrolls the TOC container with behavior 'auto' when reduced motion is preferred", () => {
+        stubMatchMedia(true);
+        const scrollTo = stubElementScrollTo();
+
+        render(
+            <NotieToc
+                tocEntries={tocEntries}
+                activeId="first-section"
+                tocTitle={tocTitle}
+            />,
+        );
+
+        expect(scrollTo).toHaveBeenCalledWith(
+            expect.objectContaining({ behavior: "auto" }),
+        );
+    });
+
+    it("scrolls the TOC container smoothly without a reduced motion preference", () => {
+        stubMatchMedia(false);
+        const scrollTo = stubElementScrollTo();
+
+        render(
+            <NotieToc
+                tocEntries={tocEntries}
+                activeId="first-section"
+                tocTitle={tocTitle}
+            />,
+        );
+
+        expect(scrollTo).toHaveBeenCalledWith(
+            expect.objectContaining({ behavior: "smooth" }),
+        );
     });
 });

--- a/src/components/NotieToc.tsx
+++ b/src/components/NotieToc.tsx
@@ -1,18 +1,32 @@
 import { Pane } from "evergreen-ui";
-import React, { useEffect, useRef } from "react";
-import { NotieConfig } from "../config/NotieConfig";
+import React, { memo, useEffect, useRef } from "react";
 import styles from "../styles/NotieToc.module.css";
 import { TocEntry } from "../utils/toc";
+import { preferredScrollBehavior } from "../utils/motion";
+
+// Per-level indentation styles are cached so list entries reuse the same
+// style object identity across renders instead of allocating a new object
+// per entry on every render.
+const entryIndentStyles = new Map<number, React.CSSProperties>();
+
+function getEntryIndentStyle(level: number): React.CSSProperties {
+    let style = entryIndentStyles.get(level);
+    if (!style) {
+        style = { marginLeft: `${level - 2}em` };
+        entryIndentStyles.set(level, style);
+    }
+    return style;
+}
 
 const NotieToc = ({
     tocEntries,
     activeId,
-    config,
+    tocTitle,
     onNavigate,
 }: {
     tocEntries: TocEntry[];
     activeId: string;
-    config: NotieConfig;
+    tocTitle: string;
     onNavigate?: (
         id: string,
         event: React.MouseEvent<HTMLAnchorElement>,
@@ -34,14 +48,14 @@ const NotieToc = ({
 
         tocContainer.scrollTo({
             top: tocContainer.scrollTop + offset,
-            behavior: "smooth",
+            behavior: preferredScrollBehavior(),
         });
     }, [activeId]);
 
     return (
         <Pane
             is="nav"
-            aria-label={config.tocTitle}
+            aria-label={tocTitle}
             position="sticky"
             top={0}
             overflowY="auto"
@@ -49,13 +63,13 @@ const NotieToc = ({
             className={styles["note-toc"]}
             ref={tocRef}
         >
-            <h1>{config.tocTitle}</h1>
+            <h2>{tocTitle}</h2>
             <hr />
             <ul>
                 {tocEntries.map((entry, index) => (
                     <li
                         key={`${entry.id}-${entry.level}-${index}`}
-                        style={{ marginLeft: `${entry.level - 2}em` }}
+                        style={getEntryIndentStyle(entry.level)}
                     >
                         <a
                             id={`toc-${entry.id}`}
@@ -76,4 +90,4 @@ const NotieToc = ({
     );
 };
 
-export default NotieToc;
+export default memo(NotieToc);

--- a/src/components/ScrollToTopButton.test.tsx
+++ b/src/components/ScrollToTopButton.test.tsx
@@ -31,6 +31,22 @@ function scrollTo(value: number) {
     });
 }
 
+function stubMatchMedia(matches: boolean) {
+    vi.stubGlobal(
+        "matchMedia",
+        vi.fn((query: string) => ({
+            matches,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })),
+    );
+}
+
 describe("ScrollToTopButton", () => {
     beforeEach(() => {
         frameCallbacks.length = 0;
@@ -45,9 +61,14 @@ describe("ScrollToTopButton", () => {
     });
 
     afterEach(() => {
+        vi.unstubAllGlobals();
         vi.restoreAllMocks();
     });
 
+    // The button stays mounted and is hidden via CSS (visibility/opacity +
+    // aria-hidden) so keyboard focus is not destroyed by unmounting. While
+    // hidden it is excluded from the accessibility tree, so default role
+    // queries must not find it.
     it("is hidden initially and stays hidden while scrolling down past 600", () => {
         render(<ScrollToTopButton />);
         expect(screen.queryByRole("button")).toBeNull();
@@ -59,6 +80,16 @@ describe("ScrollToTopButton", () => {
         expect(screen.queryByRole("button")).toBeNull();
     });
 
+    it("stays mounted in the DOM while hidden and is removed from the tab order", () => {
+        render(<ScrollToTopButton />);
+
+        expect(screen.queryByRole("button")).toBeNull();
+
+        const button = screen.getByRole("button", { hidden: true });
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveAttribute("tabindex", "-1");
+    });
+
     it("becomes visible when scrolling up while further than 600 from the top", () => {
         render(<ScrollToTopButton />);
 
@@ -66,12 +97,14 @@ describe("ScrollToTopButton", () => {
         expect(screen.queryByRole("button")).toBeNull();
 
         scrollTo(1200);
-        expect(
-            screen.getByRole("button", { name: /scroll to top/i }),
-        ).toBeInTheDocument();
+        const button = screen.getByRole("button", {
+            name: /scroll to top/i,
+        });
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveAttribute("tabindex", "0");
     });
 
-    it("hides again when scrolling up close to the top", () => {
+    it("hides again when scrolling up close to the top without unmounting", () => {
         render(<ScrollToTopButton />);
 
         scrollTo(1400);
@@ -80,6 +113,9 @@ describe("ScrollToTopButton", () => {
 
         scrollTo(300);
         expect(screen.queryByRole("button")).toBeNull();
+        expect(
+            screen.getByRole("button", { hidden: true }),
+        ).toBeInTheDocument();
     });
 
     it("scrolls smoothly to the top when clicked", () => {
@@ -96,6 +132,24 @@ describe("ScrollToTopButton", () => {
         expect(scrollToSpy).toHaveBeenCalledWith({
             top: 0,
             behavior: "smooth",
+        });
+    });
+
+    it("scrolls with behavior 'auto' when the user prefers reduced motion", () => {
+        stubMatchMedia(true);
+        const scrollToSpy = vi
+            .spyOn(window, "scrollTo")
+            .mockImplementation(() => {});
+
+        render(<ScrollToTopButton />);
+        scrollTo(1400);
+        scrollTo(1200);
+
+        fireEvent.click(screen.getByRole("button", { name: /scroll to top/i }));
+
+        expect(scrollToSpy).toHaveBeenCalledWith({
+            top: 0,
+            behavior: "auto",
         });
     });
 });

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { ArrowUpIcon, Button, Pane } from "evergreen-ui";
+import { preferredScrollBehavior } from "../utils/motion";
 
 const ScrollToTopButton = () => {
     const [isVisible, setIsVisible] = useState(false);
@@ -9,7 +10,7 @@ const ScrollToTopButton = () => {
     const scrollToTop = () => {
         window.scrollTo({
             top: 0,
-            behavior: "smooth",
+            behavior: preferredScrollBehavior(),
         });
     };
 
@@ -38,8 +39,20 @@ const ScrollToTopButton = () => {
         };
     }, []);
 
-    return isVisible ? (
-        <Pane display="flex" justifyContent="center">
+    // Keep the button mounted and toggle visibility with CSS so keyboard
+    // focus is not lost when it hides. `visibility: hidden` also removes the
+    // button from the tab order while hidden.
+    return (
+        <Pane
+            display="flex"
+            justifyContent="center"
+            style={{
+                visibility: isVisible ? "visible" : "hidden",
+                opacity: isVisible ? 1 : 0,
+                transition: "opacity 0.2s ease, visibility 0.2s ease",
+            }}
+            aria-hidden={!isVisible}
+        >
             <Pane
                 zIndex={1000}
                 position="fixed"
@@ -54,12 +67,13 @@ const ScrollToTopButton = () => {
                     onClick={scrollToTop}
                     iconBefore={ArrowUpIcon}
                     borderRadius={50}
+                    tabIndex={isVisible ? 0 : -1}
                 >
                     Scroll to Top
                 </Button>
             </Pane>
         </Pane>
-    ) : null;
+    );
 };
 
 export default ScrollToTopButton;

--- a/src/styles/Notie.module.css
+++ b/src/styles/Notie.module.css
@@ -92,6 +92,17 @@
     text-decoration: underline;
 }
 
+/* Distinct keyboard focus indicators */
+.blog-content a:focus-visible {
+    outline: 2px solid var(--blog-link-color);
+    outline-offset: 2px;
+}
+
+.blog-content summary:focus-visible {
+    outline: 2px solid var(--blog-link-color);
+    outline-offset: 2px;
+}
+
 /* inline code colors */
 .blog-content code:not([class]):not(.code-blocks code) {
     padding: 0.2em 0.4em;

--- a/src/styles/NotieToc.module.css
+++ b/src/styles/NotieToc.module.css
@@ -25,8 +25,10 @@
     text-decoration: underline;
 }
 
-.note-toc h1 {
+.note-toc h2 {
     color: var(--blog-title-color);
+    /* Preserve the visual size the TOC title had as an <h1>. */
+    font-size: 2em;
 }
 
 .note-toc hr {
@@ -47,6 +49,12 @@
 
 .note-toc a:focus {
     text-decoration: underline;
+}
+
+/* Distinct keyboard focus indicator */
+.note-toc a:focus-visible {
+    outline: 2px solid var(--note-toc-color);
+    outline-offset: 2px;
 }
 
 .note-toc a.active {

--- a/src/styles/notie-global.css
+++ b/src/styles/notie-global.css
@@ -1,3 +1,24 @@
+/* Visually hidden (screen-reader only) utility */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+/* Respect user preference for reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    html,
+    body {
+        scroll-behavior: auto;
+    }
+}
+
 /* Katex styles */
 .katex .eqn-num:before {
     content: " ";

--- a/src/utils/motion.ts
+++ b/src/utils/motion.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns the scroll behavior that respects the user's reduced-motion
+ * preference: "auto" when `prefers-reduced-motion: reduce` is set,
+ * "smooth" otherwise. Guards `matchMedia` existence for non-browser
+ * environments (e.g. jsdom or SSR).
+ */
+export function preferredScrollBehavior(): ScrollBehavior {
+    if (
+        typeof window !== "undefined" &&
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+        return "auto";
+    }
+    return "smooth";
+}


### PR DESCRIPTION
## Problem

Several accessibility gaps (NOTIE-030):
- The CodeBlock reset `IconButton` had no accessible name, and the Run button's accessible name included decorative keyboard-icon glyphs.
- The copy button's accessible name flipped between "Copy Code" and "Copied!", and screen readers got no announcement when copying succeeded.
- `window.scrollTo`/`tocContainer.scrollTo` always used `behavior: "smooth"`, ignoring `prefers-reduced-motion`.
- Links and `<summary>` elements had no distinct keyboard focus indicator.
- The TOC title was an `<h1>`, competing with the document's own `<h1>` in the heading outline.
- `ScrollToTopButton` conditionally unmounted, destroying keyboard focus when it hid.

Plus NOTIE-008: `NotieToc` re-rendered on every parent render and received the whole `config` object when it only needs the title, and allocated a fresh inline style object per entry per render.

## Solution

- `CodeBlock.tsx`: `aria-label="Reset code"` on the reset button; `aria-label="Run code (Cmd/Ctrl+Enter)"` on the run button with the decorative key icons wrapped in an `aria-hidden` span.
- `CodeHeader.tsx`: stable `aria-label="Copy code"`; a visually hidden (`.sr-only`, new utility in `notie-global.css`) `role="status"` / `aria-live="polite"` region announcing "Copied to clipboard" on success.
- Reduced motion: new `src/utils/motion.ts` `preferredScrollBehavior()` (guards `matchMedia` existence for jsdom/SSR) used by `ScrollToTopButton` and `NotieToc`; plus a `@media (prefers-reduced-motion: reduce)` block in `notie-global.css` setting `scroll-behavior: auto`.
- Focus indicators: `a:focus-visible` and `summary:focus-visible` outlines (`2px solid var(--blog-link-color)`, offset 2px) in `Notie.module.css`; `a:focus-visible` with `var(--note-toc-color)` in `NotieToc.module.css`.
- `NotieToc.tsx`: TOC title is now `<h2>` (CSS selector updated from `.note-toc h1` to `.note-toc h2`, with `font-size: 2em` to preserve the previous visual size). Component wrapped in `React.memo`, receives `tocTitle: string` instead of the whole `NotieConfig`, and per-level `marginLeft` styles are cached so entries reuse style object identity.
- `ScrollToTopButton.tsx`: stays mounted; visibility toggled via CSS `visibility`/`opacity` (with `tabIndex={-1}` and `aria-hidden` while hidden) so keyboard focus is not lost and the hidden button is not tabbable.

`Notie.test.tsx` did not need query changes: its TOC assertions use `getByRole("navigation")` and link queries, which are unaffected by the h1-to-h2 change.

## Tests

New/extended (77 total, all passing):
- `CodeBlock.test.tsx` (new): `getByRole("button", { name: /reset code/i })` and `/run code/i` resolve; key icons are inside an `aria-hidden` wrapper.
- `CodeHeader.test.tsx`: live region announces "Copied to clipboard" after click and clears after the 2s revert; accessible name stays `/copy code/i` while the visible label shows "Copied!".
- `NotieToc.test.tsx` (new): renders `<h2>` (and no `<h1>`); with `matchMedia` stubbed, `scrollTo` is called with `behavior: "auto"` under reduced motion and `"smooth"` otherwise.
- `ScrollToTopButton.test.tsx` (new): button stays in the DOM while hidden with `tabindex="-1"`; `window.scrollTo` uses `"auto"` vs `"smooth"` per reduced-motion preference.

`npm test`, `npm run lint`, `npm run build`, `npx prettier --check .` all pass. No lockfile changes.

## Risk

- Visible UI changes: keyboard users now see focus outlines on content/TOC links and collapse summaries; the scroll-to-top button fades via opacity instead of popping in/out and remains (invisibly) in the layout tree; TOC title renders as `h2` styled to match the old `h1` size (downstream CSS targeting `.note-toc h1` would no longer match, but that class is module-scoped).
- The run button's accessible name changed from icon-glyph text to "Run code (Cmd/Ctrl+Enter)"; any consumer tests querying the old name would need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)