### PR TITLE
fix: TOC ids match rehype-slug output incl. duplicate suffixing (NOTIE-024)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "bootstrap": "^5.3.3",
                 "codemirror-shiki": "^0.3.0",
                 "evergreen-ui": "^7.1.9",
+                "github-slugger": "^2.0.0",
                 "katex": "^0.16.11",
                 "react-markdown": "^9.0.1",
                 "rehype-katex": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "bootstrap": "^5.3.3",
         "codemirror-shiki": "^0.3.0",
         "evergreen-ui": "^7.1.9",
+        "github-slugger": "^2.0.0",
         "katex": "^0.16.11",
         "react-markdown": "^9.0.1",
         "rehype-katex": "^7.0.0",

--- a/src/components/Notie.test.tsx
+++ b/src/components/Notie.test.tsx
@@ -179,6 +179,108 @@ Third section.
         });
     });
 
+    it("gives every TOC entry an id that exists in the rendered DOM (tricky headings)", () => {
+        const { container } = render(
+            <Notie
+                markdown={`# Demo
+
+## Tricky Headings
+
+### C & D
+
+### It's \`code\` (v2)
+
+### Setup
+
+### Setup
+
+### See [the docs](https://example.com) here
+
+### **Bold** heading
+`}
+            />,
+        );
+
+        const toc = screen.getByRole("navigation", { name: /contents/i });
+        const ids = Array.from(toc.querySelectorAll("a[href^='#']")).map(
+            (link) => link.getAttribute("href")!.slice(1),
+        );
+
+        expect(ids).toEqual([
+            "tricky-headings",
+            "c--d",
+            "its-code-v2",
+            "setup",
+            "setup-1",
+            "see-the-docs-here",
+            "bold-heading",
+        ]);
+
+        const content = container.querySelector(
+            "[class*='blog-content']",
+        ) as HTMLElement;
+        for (const id of ids) {
+            expect(
+                content.querySelector(`[id="${CSS.escape(id)}"]`),
+                `expected a rendered element with id "${id}"`,
+            ).not.toBeNull();
+        }
+    });
+
+    it("gives every TOC entry an id that exists in the DOM with numbered headings", async () => {
+        const { container } = render(
+            <Notie
+                markdown={`# Demo
+
+## Setup
+
+### Install
+
+## Setup
+
+### Install
+
+## C & D
+`}
+                config={{ theme: { numberedHeading: true } }}
+            />,
+        );
+
+        const toc = screen.getByRole("navigation", { name: /contents/i });
+        const ids = Array.from(toc.querySelectorAll("a[href^='#']")).map(
+            (link) => link.getAttribute("href")!.slice(1),
+        );
+        expect(ids).toEqual([
+            "1setup",
+            "11install",
+            "2setup",
+            "21install",
+            "3c--d",
+        ]);
+
+        // Force all sections to render (Notie renders large notes
+        // progressively) by navigating to the last TOC entry.
+        const lastLink = within(toc)
+            .getAllByRole("link")
+            .find(
+                (link) =>
+                    link.getAttribute("href") === `#${ids[ids.length - 1]}`,
+            )!;
+        fireEvent.click(lastLink);
+
+        const content = container.querySelector(
+            "[class*='blog-content']",
+        ) as HTMLElement;
+        await waitFor(() => {
+            for (const id of ids) {
+                expect(
+                    content.querySelector(`[id="${CSS.escape(id)}"]`),
+                    `expected a rendered element with id "${id}"`,
+                ).not.toBeNull();
+            }
+        });
+    });
+
     it("rerenders when markdown content changes", () => {
         const { rerender } = render(
             <Notie markdown={"# Original\n\n## Section\n\nOriginal body."} />,

--- a/src/utils/toc.test.ts
+++ b/src/utils/toc.test.ts
@@ -67,4 +67,144 @@ describe("extractTableOfContents", () => {
             "Real Subsection",
         ]);
     });
+
+    it("suffixes duplicate headings within a section like rehype-slug", () => {
+        const markdown = `# Title
+
+## Section
+
+### Setup
+
+### Setup
+
+### Setup
+`;
+
+        const entries = extractTableOfContents(markdown);
+
+        expect(entries.map((entry) => entry.id)).toEqual([
+            "section",
+            "setup",
+            "setup-1",
+            "setup-2",
+        ]);
+    });
+
+    it("restarts duplicate suffixes at section boundaries (per-tree rehype-slug reset)", () => {
+        // Each `##` heading starts a new markdown section rendered as its
+        // own tree, and rehype-slug resets its slugger per tree, so
+        // duplicate `##` headings all get the unsuffixed slug in the DOM.
+        const markdown = `# Title
+
+## Setup
+
+### Details
+
+## Setup
+
+### Details
+`;
+
+        const entries = extractTableOfContents(markdown);
+
+        expect(entries.map((entry) => entry.id)).toEqual([
+            "setup",
+            "details",
+            "setup",
+            "details",
+        ]);
+    });
+
+    it("slugs special characters exactly like github-slugger", () => {
+        const markdown = `# Title
+
+## C & D
+
+## It's \`code\` (v2)
+
+## Q: what?
+
+## A+B
+`;
+
+        const entries = extractTableOfContents(markdown);
+
+        expect(entries.map((entry) => entry.id)).toEqual([
+            "c--d",
+            "its-code-v2",
+            "q-what",
+            "ab",
+        ]);
+    });
+
+    it("decodes the &nbsp; runs inserted by numbered headings", () => {
+        // MarkdownProcessor's numbered-heading mode rewrites headings to
+        // "2.1&nbsp;&nbsp;&nbsp;Title"; remark decodes the entities to
+        // U+00A0 before rehype-slug slugs the text, and github-slugger
+        // strips U+00A0 entirely.
+        const markdown = `# Title
+
+## 1&nbsp;&nbsp;&nbsp;Section One
+
+### 1.1&nbsp;&nbsp;&nbsp;Subsection
+`;
+
+        const entries = extractTableOfContents(markdown);
+
+        expect(entries).toEqual([
+            {
+                id: "1section-one",
+                level: 2,
+                title: "1   Section One",
+            },
+            {
+                id: "11subsection",
+                level: 3,
+                title: "1.1   Subsection",
+            },
+        ]);
+    });
+
+    it("strips markdown syntax that does not appear in rendered heading text", () => {
+        const markdown = `# Title
+
+## See [the docs](https://example.com) here
+
+## **Bold** and *italic* and ~~gone~~
+
+## Inline <em>html</em> tag
+`;
+
+        const entries = extractTableOfContents(markdown);
+
+        expect(entries.map((entry) => entry.id)).toEqual([
+            "see-the-docs-here",
+            "bold-and-italic-and-gone",
+            "inline-html-tag",
+        ]);
+        expect(entries.map((entry) => entry.title)).toEqual([
+            "See the docs here",
+            "Bold and italic and gone",
+            "Inline html tag",
+        ]);
+    });
+
+    it("counts a level-1 heading toward duplicate suffixes in its own tree", () => {
+        // The `# Title` heading lives in the first section's tree, so a
+        // `###` heading with the same text before the first `##` gets a
+        // `-1` suffix in the DOM.
+        const markdown = `# Overview
+
+### Overview
+
+## Rest
+`;
+
+        const entries = extractTableOfContents(markdown);
+
+        expect(entries.map((entry) => entry.id)).toEqual([
+            "overview-1",
+            "rest",
+        ]);
+    });
 });

--- a/src/utils/toc.ts
+++ b/src/utils/toc.ts
@@ -1,3 +1,4 @@
+import GithubSlugger from "github-slugger";
 import { maskProtectedRegions } from "./markdownMasking";
 
 export interface TocEntry {
@@ -6,36 +7,85 @@ export interface TocEntry {
     title: string;
 }
 
-export function markdownHeadingToId(title: string): string {
-    return title
-        .replace(/\s+/g, "-")
-        .toLowerCase()
-        .replace(/[+.()'`]/g, "")
-        .replace(/&nbsp;/g, "")
-        .replace(/&/g, "")
-        .replace(/:/g, "");
+/**
+ * Decode the small set of HTML character references that can realistically
+ * appear in heading source (notably the `&nbsp;` runs inserted by numbered
+ * headings). remark decodes these before rehype-slug sees the heading text,
+ * so the TOC must decode them too (`&nbsp;` becomes U+00A0, which
+ * github-slugger strips rather than turning into a dash).
+ */
+function decodeEntities(text: string): string {
+    return text
+        .replace(/&nbsp;/g, " ")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"')
+        .replace(/&#(\d+);/g, (_match, code) =>
+            String.fromCodePoint(Number(code)),
+        )
+        .replace(/&#[xX]([0-9a-fA-F]+);/g, (_match, code) =>
+            String.fromCodePoint(parseInt(code, 16)),
+        )
+        .replace(/&amp;/g, "&");
+}
+
+/**
+ * Approximate the rendered text content of a heading from its raw markdown
+ * source. rehype-slug slugs the *rendered* heading text (after markdown and
+ * inline HTML processing), while the TOC scans raw markdown, so markdown
+ * syntax that disappears from the rendered output must be stripped here:
+ * links/images (keep the text), inline HTML tags, code-span backticks,
+ * emphasis markers, and character references.
+ */
+function headingRenderedText(rawTitle: string): string {
+    return decodeEntities(
+        rawTitle
+            .replace(/\s+#+\s*$/, "") // ATX closing sequence: "## Foo ##"
+            .replace(/!\[[^\]]*\]\([^)]*\)/g, "") // images render no text
+            .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // links -> link text
+            .replace(/<[^>]*>/g, "") // inline HTML tags
+            .replace(/`+/g, "") // code-span markers
+            .replace(/\*+/g, "") // emphasis / strong markers
+            .replace(/~~/g, "") // strikethrough markers
+            // Underscore emphasis only applies at word boundaries
+            // (intraword snake_case is literal), so only strip flanking
+            // underscore runs.
+            .replace(/(^|\s)_{1,3}(?=\S)([^_]+?)_{1,3}(?=\s|$)/g, "$1$2"),
+    ).trim();
 }
 
 export function extractTableOfContents(markdownContent: string): TocEntry[] {
     const entries: TocEntry[] = [];
-    const pattern = /^#+ (.*)$/gm;
+    const pattern = /^(#+) (.*)$/gm;
     let match;
 
     // Mask code blocks and HTML comments so that `#` lines inside them are
     // never mistaken for headings.
     const { maskedText } = maskProtectedRegions(markdownContent);
 
+    // Use the same slugger as rehype-slug so TOC ids match the ids that end
+    // up in the DOM, including `-1`, `-2`, ... suffixes for duplicates.
+    let slugger = new GithubSlugger();
+
     while ((match = pattern.exec(maskedText)) !== null) {
-        const [fullMatch, title] = match;
-        const level = fullMatch.match(/^#+/)?.[0].length || 0;
+        const level = match[1].length;
+        const title = headingRenderedText(match[2]);
+
+        // Every `##` heading starts a new markdown section, and each section
+        // is rendered as its own tree; rehype-slug resets its slugger at the
+        // start of every tree, so duplicate suffixes restart at each section
+        // boundary. Mirror that by resetting at every level-2 heading.
+        if (level === 2) {
+            slugger = new GithubSlugger();
+        }
+
+        const id = slugger.slug(title);
+
+        // The level-1 title is not listed in the TOC, but it still consumes
+        // a slug in its section's tree.
         if (level === 1) continue;
 
-        const cleanedTitle = title.replace(/[*]/g, "").trim();
-        entries.push({
-            id: markdownHeadingToId(cleanedTitle),
-            level,
-            title: cleanedTitle.replace(/&nbsp;/g, "\u00a0"),
-        });
+        entries.push({ id, level, title });
     }
 
     return entries;


### PR DESCRIPTION
## Problem

`extractTableOfContents` built heading ids with a custom transform chain (`markdownHeadingToId`), while the rendered DOM gets its heading ids from rehype-slug, which uses github-slugger. Two failure modes:

- **Duplicate headings**: rehype-slug suffixes repeats as `foo-1`, `foo-2`, but the TOC emitted `foo` for all of them, so TOC links for repeated headings always jumped to the first occurrence.
- **Algorithm mismatch**: special characters diverged (`C & D` → DOM `c--d` vs TOC `c-d`; `It's \`code\` (v2)` → DOM `its-code-v2` vs TOC `it's-`\`code\``-v2`; etc.), producing dead TOC links.

## Solution

- `src/utils/toc.ts` now slugs headings with `github-slugger` — the exact library rehype-slug uses — so ids match by construction, including duplicate `-1`/`-2` suffixing.
- **Per-section slugger reset**: Notie renders each `##` section as its own ReactMarkdown tree, and rehype-slug resets its slugger per tree. The TOC mirrors this by resetting the slugger at every level-2 heading (verified empirically via integration tests — duplicate `##` headings across sections get *unsuffixed* ids in the DOM, and the TOC now matches that, dupes and all). The level-1 title still consumes a slug in the first section's tree before being skipped.
- **Rendered-text approximation**: rehype-slug slugs the rendered text of the heading, while the TOC sees raw markdown. Before slugging, we now strip markdown links/images (keeping link text), inline HTML tags, code-span backticks, emphasis/strong/strikethrough markers, and decode common character references — notably the `&nbsp;` runs inserted by numbered-heading mode (decoded to U+00A0, which github-slugger strips, matching the DOM's `21section-one`-style ids).
- Removed `markdownHeadingToId` — grep confirms no other usages, and it was never exported from `src/index.ts` (public API is only the `Notie` component + config types).
- `NotieToc`/`handleTocNavigate` unchanged — they consume `entry.id`.
- Kept the recent `maskProtectedRegions` masking before scanning.

## Dependency / lockfile note (for orchestrator review)

`github-slugger@^2.0.0` added to `package.json` dependencies (it becomes a direct import; it was already in the tree as rehype-slug's dependency, deduped at the root of `node_modules`). The `package-lock.json` diff is exactly one line — the root package's dependencies block:

```diff
                 "evergreen-ui": "^7.1.9",
+                "github-slugger": "^2.0.0",
                 "katex": "^0.16.11",
```

No `node_modules/github-slugger` entry change was needed (already present at the correct version/integrity). A full `npm install` regeneration also wanted to delete ~500 lines of unrelated `vitest/node_modules/@esbuild/*` peer-dep entries (lockfile drift from a different npm version), so I applied the minimal one-line change instead and verified it with `npm ls github-slugger` (resolves and dedupes cleanly).

## Tests

- **Integration (`src/components/Notie.test.tsx`)**: renders `<Notie>` with tricky headings (duplicates, `C & D`, `It's \`code\` (v2)`, markdown links, bold) and asserts every TOC href resolves to a rendered element via `container.querySelector(`[id="${id}"]`)`; second test does the same with `numberedHeading: true` and duplicate `##` sections, clicking the last TOC link to force all progressive sections to render first.
- **Unit (`src/utils/toc.test.ts`)**: duplicate → `-1`/`-2` suffixes within a section; suffix reset at section boundaries; github-slugger special-character outputs (`c--d`, `its-code-v2`, `q-what`, `ab`); `&nbsp;` decoding for numbered headings; markdown/HTML stripping; level-1 title consuming a slug in its tree.
- Full suite: 75/75 tests pass; lint, build, and prettier clean.

## Risk

- The per-section reset intentionally produces *duplicate* TOC ids when two `##` sections share a title — this faithfully mirrors the current DOM (both headings get the same unsuffixed id), so links go to the first occurrence, same as raw HTML anchor semantics. Fixing that would require changing how sections are rendered (single-tree rendering or a shared slugger via rehype-slug options), out of scope here.
- The rendered-text approximation is regex-based, not a full markdown parse; exotic heading markup (nested emphasis edge cases, raw entities beyond the common set) could still diverge. The integration test guards the realistic cases.
- If the renderer ever stops splitting per `##` section (or rehype-slug stops resetting per tree), the reset-per-section logic in `toc.ts` must change with it — noted in a comment at the reset site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)