### PR TITLE
perf: coalesce DOM numbering/observer effects during progressive reveal (NOTIE-006)

### DIFF
--- a/src/components/Notie.reveal.test.tsx
+++ b/src/components/Notie.reveal.test.tsx
@@ -56,47 +56,62 @@ describe("Notie progressive reveal coalescing", () => {
         globalThis.IntersectionObserver = OriginalIntersectionObserver;
     });
 
-    it("coalesces observer rebuilds and DOM numbering across a burst of section reveals", async () => {
-        const { container } = render(
-            <Notie
-                markdown={buildMarkdown()}
-                config={{ theme: { blockquoteStyle: "latex" } }}
-            />,
-        );
+    // Generous test timeout: progressive reveal ticks + KaTeX rendering can
+    // be slow on CI runners (the vitest default of 5s has proven flaky).
+    it(
+        "coalesces observer rebuilds and DOM numbering across a burst of section reveals",
+        { timeout: 30000 },
+        async () => {
+            const { container } = render(
+                <Notie
+                    markdown={buildMarkdown()}
+                    config={{ theme: { blockquoteStyle: "latex" } }}
+                />,
+            );
 
-        // Sections are revealed progressively; wait for the last one.
-        await waitFor(() => {
+            // Sections are revealed progressively (one setTimeout(16) fallback
+            // tick per section in jsdom); slower CI runners can take well over
+            // the default 1s waitFor timeout for all reveals plus KaTeX
+            // rendering, so wait generously.
+            await waitFor(
+                () => {
+                    expect(
+                        screen.getByText(`Body of section ${SECTION_COUNT}.`),
+                    ).toBeInTheDocument();
+                },
+                { timeout: 10000 },
+            );
+
+            // Final numbering must settle shortly after the last reveal (the
+            // rescan is debounced with a short trailing delay).
+            await waitFor(
+                () => {
+                    expect(
+                        container.querySelector(`#eqn-${SECTION_COUNT}\\.1`),
+                    ).toHaveTextContent(`(${SECTION_COUNT}.1)`);
+                },
+                { timeout: 10000 },
+            );
+            expect(container.querySelector("#eqn-1\\.1")).toHaveTextContent(
+                "(1.1)",
+            );
             expect(
-                screen.getByText(`Body of section ${SECTION_COUNT}.`),
-            ).toBeInTheDocument();
-        });
-
-        // Final numbering must settle shortly after the last reveal (the
-        // rescan is debounced with a short trailing delay).
-        await waitFor(() => {
+                container.querySelector(
+                    `[blockquote-definition-number="Definition ${SECTION_COUNT}.1"]`,
+                ),
+            ).not.toBeNull();
             expect(
-                container.querySelector(`#eqn-${SECTION_COUNT}\\.1`),
-            ).toHaveTextContent(`(${SECTION_COUNT}.1)`);
-        });
-        expect(container.querySelector("#eqn-1\\.1")).toHaveTextContent(
-            "(1.1)",
-        );
-        expect(
-            container.querySelector(
-                `[blockquote-definition-number="Definition ${SECTION_COUNT}.1"]`,
-            ),
-        ).not.toBeNull();
-        expect(
-            container.querySelector(
-                '[blockquote-definition-number="Definition 1.1"]',
-            ),
-        ).not.toBeNull();
+                container.querySelector(
+                    '[blockquote-definition-number="Definition 1.1"]',
+                ),
+            ).not.toBeNull();
 
-        // The heading IntersectionObserver must be rebuilt only a handful of
-        // times (initial sync run + coalesced trailing runs), not once per
-        // revealed section.
-        expect(observerConstructions).toBeGreaterThan(0);
-        expect(observerConstructions).toBeLessThanOrEqual(3);
-        expect(observerConstructions).toBeLessThan(SECTION_COUNT);
-    });
+            // The heading IntersectionObserver must be rebuilt only a handful of
+            // times (initial sync run + coalesced trailing runs), not once per
+            // revealed section.
+            expect(observerConstructions).toBeGreaterThan(0);
+            expect(observerConstructions).toBeLessThanOrEqual(3);
+            expect(observerConstructions).toBeLessThan(SECTION_COUNT);
+        },
+    );
 });

--- a/src/components/Notie.reveal.test.tsx
+++ b/src/components/Notie.reveal.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import Notie from "./Notie";
+
+const SECTION_COUNT = 8;
+
+function buildMarkdown(): string {
+    let markdown = "# Demo\n\n";
+    for (let i = 1; i <= SECTION_COUNT; i++) {
+        markdown += `## Section ${i}
+
+Body of section ${i}.
+
+$$
+\\begin{equation} \\label{eq:s${i}}
+x_{${i}} = ${i}
+\\end{equation}
+$$
+
+<blockquote class="definition" id="def:s${i}">
+Definition body ${i}.
+</blockquote>
+
+`;
+    }
+    return markdown;
+}
+
+describe("Notie progressive reveal coalescing", () => {
+    const OriginalIntersectionObserver = window.IntersectionObserver;
+    let observerConstructions: number;
+
+    beforeEach(() => {
+        window.history.replaceState(null, "", "/");
+        observerConstructions = 0;
+
+        const Original = OriginalIntersectionObserver;
+        class CountingIntersectionObserver extends Original {
+            constructor(
+                callback: IntersectionObserverCallback,
+                options?: IntersectionObserverInit,
+            ) {
+                super(callback, options);
+                observerConstructions++;
+            }
+        }
+
+        // The setup.ts mock is defined writable but not configurable, so
+        // assign directly instead of using vi.stubGlobal (defineProperty).
+        window.IntersectionObserver = CountingIntersectionObserver;
+        globalThis.IntersectionObserver = CountingIntersectionObserver;
+    });
+
+    afterEach(() => {
+        window.IntersectionObserver = OriginalIntersectionObserver;
+        globalThis.IntersectionObserver = OriginalIntersectionObserver;
+    });
+
+    it("coalesces observer rebuilds and DOM numbering across a burst of section reveals", async () => {
+        const { container } = render(
+            <Notie
+                markdown={buildMarkdown()}
+                config={{ theme: { blockquoteStyle: "latex" } }}
+            />,
+        );
+
+        // Sections are revealed progressively; wait for the last one.
+        await waitFor(() => {
+            expect(
+                screen.getByText(`Body of section ${SECTION_COUNT}.`),
+            ).toBeInTheDocument();
+        });
+
+        // Final numbering must settle shortly after the last reveal (the
+        // rescan is debounced with a short trailing delay).
+        await waitFor(() => {
+            expect(
+                container.querySelector(`#eqn-${SECTION_COUNT}\\.1`),
+            ).toHaveTextContent(`(${SECTION_COUNT}.1)`);
+        });
+        expect(container.querySelector("#eqn-1\\.1")).toHaveTextContent(
+            "(1.1)",
+        );
+        expect(
+            container.querySelector(
+                `[blockquote-definition-number="Definition ${SECTION_COUNT}.1"]`,
+            ),
+        ).not.toBeNull();
+        expect(
+            container.querySelector(
+                '[blockquote-definition-number="Definition 1.1"]',
+            ),
+        ).not.toBeNull();
+
+        // The heading IntersectionObserver must be rebuilt only a handful of
+        // times (initial sync run + coalesced trailing runs), not once per
+        // revealed section.
+        expect(observerConstructions).toBeGreaterThan(0);
+        expect(observerConstructions).toBeLessThanOrEqual(3);
+        expect(observerConstructions).toBeLessThan(SECTION_COUNT);
+    });
+});

--- a/src/components/Notie.reveal.test.tsx
+++ b/src/components/Notie.reveal.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Notie from "./Notie";
 
 const SECTION_COUNT = 8;
@@ -34,6 +34,13 @@ describe("Notie progressive reveal coalescing", () => {
         window.history.replaceState(null, "", "/");
         observerConstructions = 0;
 
+        // Fake timers make the reveal cadence deterministic. On real (slow
+        // CI) clocks a single section reveal can take longer than the
+        // trailing debounce window, in which case every reveal legitimately
+        // gets its own rescan and the coalescing assertion below would
+        // depend on machine speed.
+        vi.useFakeTimers();
+
         const Original = OriginalIntersectionObserver;
         class CountingIntersectionObserver extends Original {
             constructor(
@@ -52,66 +59,60 @@ describe("Notie progressive reveal coalescing", () => {
     });
 
     afterEach(() => {
+        vi.useRealTimers();
         window.IntersectionObserver = OriginalIntersectionObserver;
         globalThis.IntersectionObserver = OriginalIntersectionObserver;
     });
 
-    // Generous test timeout: progressive reveal ticks + KaTeX rendering can
-    // be slow on CI runners (the vitest default of 5s has proven flaky).
-    it(
-        "coalesces observer rebuilds and DOM numbering across a burst of section reveals",
-        { timeout: 30000 },
-        async () => {
-            const { container } = render(
-                <Notie
-                    markdown={buildMarkdown()}
-                    config={{ theme: { blockquoteStyle: "latex" } }}
-                />,
-            );
+    it("coalesces observer rebuilds and DOM numbering across a burst of section reveals", async () => {
+        const { container } = render(
+            <Notie
+                markdown={buildMarkdown()}
+                config={{ theme: { blockquoteStyle: "latex" } }}
+            />,
+        );
 
-            // Sections are revealed progressively (one setTimeout(16) fallback
-            // tick per section in jsdom); slower CI runners can take well over
-            // the default 1s waitFor timeout for all reveals plus KaTeX
-            // rendering, so wait generously.
-            await waitFor(
-                () => {
-                    expect(
-                        screen.getByText(`Body of section ${SECTION_COUNT}.`),
-                    ).toBeInTheDocument();
-                },
-                { timeout: 10000 },
-            );
+        // Sections are revealed progressively, one per scheduler tick
+        // (jsdom has no requestIdleCallback, so MarkdownRenderer falls back
+        // to setTimeout(16)). Advance fake time tick by tick — faster than
+        // the trailing debounce — until every section is revealed.
+        const lastSectionRevealed = () =>
+            screen.queryByText(`Body of section ${SECTION_COUNT}.`) !== null;
+        for (let i = 0; i < SECTION_COUNT * 4 && !lastSectionRevealed(); i++) {
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(16);
+            });
+        }
+        expect(lastSectionRevealed()).toBe(true);
 
-            // Final numbering must settle shortly after the last reveal (the
-            // rescan is debounced with a short trailing delay).
-            await waitFor(
-                () => {
-                    expect(
-                        container.querySelector(`#eqn-${SECTION_COUNT}\\.1`),
-                    ).toHaveTextContent(`(${SECTION_COUNT}.1)`);
-                },
-                { timeout: 10000 },
-            );
-            expect(container.querySelector("#eqn-1\\.1")).toHaveTextContent(
-                "(1.1)",
-            );
-            expect(
-                container.querySelector(
-                    `[blockquote-definition-number="Definition ${SECTION_COUNT}.1"]`,
-                ),
-            ).not.toBeNull();
-            expect(
-                container.querySelector(
-                    '[blockquote-definition-number="Definition 1.1"]',
-                ),
-            ).not.toBeNull();
+        // Let the trailing debounce fire the single coalesced rescan.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(200);
+        });
 
-            // The heading IntersectionObserver must be rebuilt only a handful of
-            // times (initial sync run + coalesced trailing runs), not once per
-            // revealed section.
-            expect(observerConstructions).toBeGreaterThan(0);
-            expect(observerConstructions).toBeLessThanOrEqual(3);
-            expect(observerConstructions).toBeLessThan(SECTION_COUNT);
-        },
-    );
+        // Final numbering must be correct once the burst settles.
+        expect(
+            container.querySelector(`#eqn-${SECTION_COUNT}\\.1`),
+        ).toHaveTextContent(`(${SECTION_COUNT}.1)`);
+        expect(container.querySelector("#eqn-1\\.1")).toHaveTextContent(
+            "(1.1)",
+        );
+        expect(
+            container.querySelector(
+                `[blockquote-definition-number="Definition ${SECTION_COUNT}.1"]`,
+            ),
+        ).not.toBeNull();
+        expect(
+            container.querySelector(
+                '[blockquote-definition-number="Definition 1.1"]',
+            ),
+        ).not.toBeNull();
+
+        // The heading IntersectionObserver must be rebuilt only a handful
+        // of times (initial sync run + coalesced trailing run), not once
+        // per revealed section.
+        expect(observerConstructions).toBeGreaterThan(0);
+        expect(observerConstructions).toBeLessThanOrEqual(3);
+        expect(observerConstructions).toBeLessThan(SECTION_COUNT);
+    });
 });

--- a/src/components/Notie.tsx
+++ b/src/components/Notie.tsx
@@ -29,6 +29,79 @@ export interface NotieProps {
     };
 }
 
+/**
+ * Trailing delay applied to full-document DOM rescans while sections are
+ * being progressively revealed. Must stay short (<= 100ms) so equation and
+ * blockquote numbers are never visibly stale after the last reveal.
+ */
+const REVEAL_RESCAN_DELAY_MS = 50;
+
+const NEVER_RAN = Symbol("never-ran");
+
+/**
+ * Runs `effect` like `useEffect`, but coalesces bursts of
+ * `renderedSectionCount` changes caused by progressive section reveal.
+ *
+ * `MarkdownRenderer` reveals sections one at a time (one idle callback per
+ * section), and the heading observer plus equation/blockquote numbering
+ * effects each rescan the whole document on every reveal — O(N^2) work over
+ * the reveal sequence for large documents. This hook instead:
+ *
+ * - runs `effect` synchronously whenever `syncKey` changes (including on
+ *   mount), so numbering and observers are correct immediately for the
+ *   initially rendered content and after document updates;
+ * - debounces `renderedSectionCount` changes with a short trailing delay,
+ *   so a burst of reveals triggers a single rescan shortly after the last
+ *   one.
+ *
+ * `effect` may return a cleanup function (e.g. to disconnect an
+ * IntersectionObserver); it is invoked before the next run and on unmount.
+ */
+function useCoalescedRevealEffect(
+    effect: () => void | (() => void),
+    syncKey: unknown,
+    renderedSectionCount: number,
+) {
+    const effectRef = useRef(effect);
+    useEffect(() => {
+        effectRef.current = effect;
+    });
+
+    const cleanupRef = useRef<(() => void) | null>(null);
+    const previousSyncKeyRef = useRef<unknown>(NEVER_RAN);
+
+    const runEffect = useCallback(() => {
+        cleanupRef.current?.();
+        const cleanup = effectRef.current();
+        cleanupRef.current = typeof cleanup === "function" ? cleanup : null;
+    }, []);
+
+    useEffect(() => {
+        // `renderedSectionCount` is intentionally an effect trigger rather
+        // than an input: each progressive reveal restarts the trailing
+        // debounce below.
+        void renderedSectionCount;
+
+        if (!Object.is(previousSyncKeyRef.current, syncKey)) {
+            previousSyncKeyRef.current = syncKey;
+            runEffect();
+            return;
+        }
+
+        const timeoutId = window.setTimeout(runEffect, REVEAL_RESCAN_DELAY_MS);
+        return () => window.clearTimeout(timeoutId);
+    }, [runEffect, syncKey, renderedSectionCount]);
+
+    // Run the last effect cleanup (e.g. disconnect the observer) on unmount.
+    useEffect(
+        () => () => {
+            cleanupRef.current?.();
+            cleanupRef.current = null;
+        },
+        [],
+    );
+}
+
 const Notie: React.FC<NotieProps> = ({
     markdown,
     config: userConfig,
@@ -104,33 +177,41 @@ const Notie: React.FC<NotieProps> = ({
         setPendingScrollId(null);
     }, [pendingScrollId, renderedSectionCount]);
 
-    // Effect to observe headings and update activeId
-    useEffect(() => {
-        if (!contentRef.current) return;
-        const observerOptions = {
-            rootMargin: "0px 0px -90% 0px",
-            threshold: 0,
-        };
+    // Effect to observe headings and update activeId. Coalesced so that a
+    // burst of progressive section reveals rebuilds the observer once at the
+    // end instead of once per revealed section.
+    useCoalescedRevealEffect(
+        useCallback(() => {
+            if (!contentRef.current) return;
+            const observerOptions = {
+                rootMargin: "0px 0px -90% 0px",
+                threshold: 0,
+            };
 
-        const headings = contentRef.current.querySelectorAll(
-            "h1, h2, h3, h4, h5, h6",
-        );
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach((entry) => {
-                if (entry.isIntersecting) {
-                    const id = entry.target.id;
-                    setActiveId((current) => (current === id ? current : id));
-                }
-            });
-        }, observerOptions);
+            const headings = contentRef.current.querySelectorAll(
+                "h1, h2, h3, h4, h5, h6",
+            );
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        const id = entry.target.id;
+                        setActiveId((current) =>
+                            current === id ? current : id,
+                        );
+                    }
+                });
+            }, observerOptions);
 
-        headings.forEach((heading) => observer.observe(heading));
+            headings.forEach((heading) => observer.observe(heading));
 
-        return () => observer.disconnect();
-    }, [markdownContent, renderedSectionCount]);
+            return () => observer.disconnect();
+        }, []),
+        markdownContent,
+        renderedSectionCount,
+    );
 
-    // Effect to auto label equation numbers
-    useEffect(() => {
+    // Effect to auto label equation numbers. Coalesced: see above.
+    const labelEquationNumbers = useCallback(() => {
         if (!contentRef.current) return;
         const sections = contentRef.current.getElementsByClassName("sections");
 
@@ -147,10 +228,16 @@ const Notie: React.FC<NotieProps> = ({
                 eqn.textContent = `(${sectionIndex + 1}.${eqnIndex + 1})`;
             }
         }
-    }, [markdownContent, renderedSectionCount]);
+    }, []);
+    useCoalescedRevealEffect(
+        labelEquationNumbers,
+        markdownContent,
+        renderedSectionCount,
+    );
 
-    // Effect to auto label Definitions, Theorems, Lemmas, only for LaTeX style
-    useEffect(() => {
+    // Effect to auto label Definitions, Theorems, Lemmas, only for LaTeX
+    // style. Coalesced: see above.
+    const labelLatexBlockquotes = useCallback(() => {
         if (config.theme.blockquoteStyle !== "latex") return;
         if (!contentRef.current) return;
         const sections = contentRef.current.getElementsByClassName("sections");
@@ -201,7 +288,14 @@ const Notie: React.FC<NotieProps> = ({
                 }
             });
         }
-    }, [config.theme.blockquoteStyle, markdownContent, renderedSectionCount]);
+    }, [config.theme.blockquoteStyle]);
+    useCoalescedRevealEffect(
+        labelLatexBlockquotes,
+        // Re-run synchronously when either the document content or the
+        // blockquote style changes (string sync keys compare by value).
+        `${config.theme.blockquoteStyle}\n${markdownContent}`,
+        renderedSectionCount,
+    );
 
     return (
         <Pane className={styles["notie-container"]}>


### PR DESCRIPTION
## Problem

`MarkdownRenderer` reveals sections progressively — `renderedSectionCount` increments once per idle callback. Three effects in `src/components/Notie.tsx` were keyed on `[markdownContent, renderedSectionCount]`, so every single reveal triggered:

- a full `querySelectorAll("h1..h6")` scan plus a complete teardown/rebuild of the heading `IntersectionObserver`,
- a full-document equation-number rescan (`.sections` x `.eqn-num`),
- a full-document LaTeX blockquote-number rescan (definitions/theorems/lemmas/algorithms/problems).

For an N-section document that is O(N²) DOM work over the reveal sequence, which dominates main-thread time on large notes.

## Solution

New `useCoalescedRevealEffect(effect, syncKey, renderedSectionCount)` helper (no new dependencies, inline in `Notie.tsx`):

- Runs the effect **synchronously** whenever the sync key (document content, plus blockquote style for the blockquote effect) changes — including on mount — so numbering/observers are immediately correct for short documents and after markdown updates.
- **Debounces** `renderedSectionCount` bursts with a 50ms trailing timeout (well under the 100ms staleness budget), so a burst of reveals causes exactly one rescan/observer rebuild shortly after the last increment.
- Effect cleanups (observer `disconnect`) still run before each rerun and on unmount.

The cheap hash-scroll `pendingScrollId` effect is intentionally left un-debounced, so TOC navigation to not-yet-rendered sections still scrolls on the exact tick the target appears. TOC active tracking is unchanged.

## Tests

- New `src/components/Notie.reveal.test.tsx`: drives the 8-section progressive reveal with `vi.useFakeTimers()` (deterministic on any machine speed — the initial wall-clock version was flaky on slow CI runners where a reveal tick could exceed the debounce window). Advances time 16ms per reveal tick, then past the 50ms trailing debounce, and asserts the heading `IntersectionObserver` was constructed at most 3 times (9 against the pre-coalescing implementation — verified) while final numbering is correct: `#eqn-8.1` has text `(8.1)`, `#eqn-1.1` has `(1.1)`, and `blockquote-definition-number` attributes exist for sections 1 and 8.
- Existing `Notie.test.tsx` passes **unmodified**, including the progressive rendering + TOC navigation tests.
- Full suite: 148 tests / 23 files pass (run repeatedly for flake confidence); `npm run lint`, `npm run build`, and `npx prettier --check .` all clean.

## Risk

- Low. During a reveal burst, newly appended sections can show unnumbered equations/blockquotes for up to ~50ms after the burst settles — bounded by the trailing debounce and invisible in practice.
- The heading observer is still fully rebuilt (not incrementally extended), but now once per settled burst instead of once per section; behavior at rest is identical to before.
- Cleanup ordering preserved: the previous observer is disconnected before a new one is created, and on unmount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
