### PR TITLE
feat: customComponents receive block config; export public utility types and helpers (NOTIE-042)

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -20,7 +20,7 @@ import { InlineAlert } from "evergreen-ui";
 import LazyRender from "./LazyRender";
 import StaticCodeBlock from "./StaticCodeBlock";
 import TikZ from "./TikZ";
-import { FullNotieConfig } from "../config/NotieConfig";
+import { CustomComponents, FullNotieConfig } from "../config/NotieConfig";
 
 type CodeProps = React.HTMLAttributes<HTMLElement> & {
     node?: unknown;
@@ -31,7 +31,7 @@ type CodeProps = React.HTMLAttributes<HTMLElement> & {
 
 type CustomComponentFormat = {
     componentName: string;
-};
+} & Record<string, unknown>;
 
 type AnchorProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
     node?: unknown;
@@ -102,9 +102,7 @@ const MarkdownRenderer: React.FC<{
     config: FullNotieConfig;
     equationMapping: EquationMapping;
     blockquoteMapping: BlockquoteMapping;
-    customComponents?: {
-        [key: string]: () => JSX.Element;
-    };
+    customComponents?: CustomComponents;
     renderAllToken?: number;
     onRenderedSectionsChange?: (renderedSectionCount: number) => void;
 }> = React.memo(
@@ -303,7 +301,9 @@ const MarkdownRenderer: React.FC<{
                                 customComponents[componentConfig.componentName];
 
                             if (CustomComponent) {
-                                return <CustomComponent />;
+                                return (
+                                    <CustomComponent config={componentConfig} />
+                                );
                             } else {
                                 return (
                                     <InlineAlert intent="danger">

--- a/src/components/Notie.componentBlock.test.tsx
+++ b/src/components/Notie.componentBlock.test.tsx
@@ -1,6 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import Notie from "./Notie";
+import type { CustomComponentProps } from "../config/NotieConfig";
+import {
+    extractTableOfContents,
+    sanitizeUrl,
+    type CustomComponents,
+    type TocEntry,
+} from "../index";
 
 describe("Notie component code blocks", () => {
     it("renders an alert instead of crashing when the component JSON is invalid", () => {
@@ -71,5 +78,81 @@ describe("Notie component code blocks", () => {
         );
 
         expect(screen.getByTestId("custom-widget")).toHaveTextContent("Widget");
+    });
+
+    it("passes the parsed component block JSON to the component as `config`", () => {
+        const seenConfigs: Array<CustomComponentProps["config"]> = [];
+        const Widget = ({ config }: CustomComponentProps) => {
+            seenConfigs.push(config);
+            return (
+                <div data-testid="configured-widget">
+                    {String(config?.label)}
+                </div>
+            );
+        };
+        const customComponents: CustomComponents = { Widget };
+
+        render(
+            <Notie
+                markdown={`# Demo
+
+\`\`\`component
+{
+    componentName: "Widget",
+    label: "hello",
+    count: 3,
+    nested: { flag: true }
+}
+\`\`\`
+`}
+                customComponents={customComponents}
+            />,
+        );
+
+        expect(screen.getByTestId("configured-widget")).toHaveTextContent(
+            "hello",
+        );
+        expect(seenConfigs.length).toBeGreaterThan(0);
+        expect(seenConfigs[0]).toEqual({
+            componentName: "Widget",
+            label: "hello",
+            count: 3,
+            nested: { flag: true },
+        });
+    });
+
+    it("still renders zero-prop legacy components", () => {
+        render(
+            <Notie
+                markdown={`# Demo
+
+\`\`\`component
+{
+    componentName: "Legacy",
+    ignored: "value"
+}
+\`\`\`
+`}
+                customComponents={{
+                    Legacy: () => <div data-testid="legacy-widget">Legacy</div>,
+                }}
+            />,
+        );
+
+        expect(screen.getByTestId("legacy-widget")).toHaveTextContent("Legacy");
+    });
+
+    it("exposes sanitizeUrl and extractTableOfContents from the public API", () => {
+        expect(sanitizeUrl("javascript:alert(1)")).toBe("");
+        expect(sanitizeUrl("https://example.com/")).toBe(
+            "https://example.com/",
+        );
+
+        const entries: TocEntry[] = extractTableOfContents(
+            "# Title\n\n## Section",
+        );
+        expect(entries).toEqual([
+            { id: "section", level: 2, title: "Section" },
+        ]);
     });
 });

--- a/src/components/Notie.tsx
+++ b/src/components/Notie.tsx
@@ -15,7 +15,11 @@ import ScrollToTopButton from "./ScrollToTopButton";
 import NoteToc from "./NotieToc";
 import MarkdownRenderer from "./MarkdownRenderer";
 import { MarkdownProcessor } from "../utils/MarkdownProcessor";
-import { NotieConfig, NotieThemes } from "../config/NotieConfig";
+import {
+    CustomComponents,
+    NotieConfig,
+    NotieThemes,
+} from "../config/NotieConfig";
 import { useNotieConfig } from "../utils/useNotieConfig";
 import { useShallowStableObject } from "../utils/useShallowStableObject";
 import { extractTableOfContents } from "../utils/toc";
@@ -24,9 +28,7 @@ export interface NotieProps {
     markdown: string;
     config?: NotieConfig;
     theme?: NotieThemes;
-    customComponents?: {
-        [key: string]: () => JSX.Element;
-    };
+    customComponents?: CustomComponents;
 }
 
 /**

--- a/src/config/NotieConfig.tsx
+++ b/src/config/NotieConfig.tsx
@@ -1,3 +1,4 @@
+import type { ComponentType } from "react";
 import type { BundledTheme } from "shiki";
 
 type LiveCodeBlockThemeNames = BundledTheme;
@@ -56,6 +57,25 @@ export type NotieThemes =
     | "default dark"
     | "Starlit Eclipse"
     | "Starlit Eclipse Light";
+
+/**
+ * Props passed to a custom component rendered from a ```component code
+ * block. `config` is the full parsed JSON object from the code block
+ * (including `componentName`). Zero-prop legacy components
+ * (`() => JSX.Element`) remain compatible and simply ignore it.
+ */
+export interface CustomComponentProps {
+    config?: Record<string, unknown>;
+}
+
+/**
+ * Map from `componentName` (as referenced in ```component code blocks) to
+ * the React component that renders it.
+ */
+export type CustomComponents = Record<
+    string,
+    ComponentType<CustomComponentProps>
+>;
 
 // FullTheme and FullNotieConfig are the types that are used in notie
 export type FullTheme = Required<Theme>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,13 @@
 export { default as Notie } from "./components/Notie";
+export { sanitizeUrl } from "./utils/sanitizeUrl";
+export { extractTableOfContents } from "./utils/toc";
 export type { NotieConfig, NotieThemes } from "./config/NotieConfig";
 export type { NotieProps } from "./components/Notie";
-export type { Theme } from "./config/NotieConfig";
+export type {
+    CustomComponentProps,
+    CustomComponents,
+    FullNotieConfig,
+    FullTheme,
+    Theme,
+} from "./config/NotieConfig";
+export type { TocEntry } from "./utils/toc";


### PR DESCRIPTION
## Problem

- `customComponents` was typed inline (and duplicated) in both `Notie.tsx` and `MarkdownRenderer.tsx` as `{ [key: string]: () => JSX.Element }`, so custom components could not receive any data from their ````component``` code block — extra JSON fields in the block were parsed and then discarded.
- Useful, already-tested utilities (`sanitizeUrl`, `extractTableOfContents`) and types (`FullNotieConfig`, `FullTheme`, `TocEntry`) were internal-only, forcing consumers to reimplement them.

## Solution

- Added a single shared contract in `src/config/NotieConfig.tsx`:
  - `export interface CustomComponentProps { config?: Record<string, unknown> }`
  - `export type CustomComponents = Record<string, React.ComponentType<CustomComponentProps>>`
- `Notie.tsx` and `MarkdownRenderer.tsx` now use the shared type (duplicated inline types removed).
- The component-block render path now passes the full parsed JSON object (including `componentName`) through: `<CustomComponent config={componentConfig} />`.
- Public API (`src/index.ts`) now exports `sanitizeUrl`, `extractTableOfContents`, and types `FullNotieConfig`, `FullTheme`, `TocEntry`, `CustomComponents`, `CustomComponentProps`. Verified they appear in `dist/index.d.ts` after build.

## Backward compatibility

Existing consumers pass zero-prop function components (`() => <div/>`); `ComponentType<CustomComponentProps>` accepts those, so no consumer changes are required. Existing component-block tests stay green.

## Tests

- New: custom component receives the parsed block JSON (extra fields `label`, `count`, nested object) as its `config` prop.
- New: zero-prop legacy component still renders when the block carries extra fields.
- New: `sanitizeUrl` / `extractTableOfContents` / `TocEntry` / `CustomComponents` resolve via `../index` and behave as expected.
- Full suite: 151 tests / 23 files pass. `npm run lint`, `npm run build`, and `npx prettier --check .` all pass. No `package-lock.json` changes.

## Risk

Low. The only runtime behavior change is passing a previously-unused prop to custom components; components that ignore props are unaffected. Type widening from `() => JSX.Element` to `ComponentType<CustomComponentProps>` is strictly more permissive for consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)