### PR TITLE
fix(deps): bump katex for GHSA-cg87-wmx4-v546; exclude sourcemaps from npm tarball (NOTIE-040/041)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "codemirror-shiki": "^0.3.0",
                 "evergreen-ui": "^7.1.9",
                 "github-slugger": "^2.0.0",
-                "katex": "^0.16.11",
+                "katex": "^0.16.22",
                 "react-markdown": "^9.0.1",
                 "rehype-katex": "^7.0.0",
                 "rehype-raw": "^7.0.0",
@@ -5485,9 +5485,9 @@
             }
         },
         "node_modules/katex": {
-            "version": "0.16.11",
-            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.11.tgz",
-            "integrity": "sha512-RQrI8rlHY92OLf3rho/Ts8i/XvjgguEjOkO1BEXcU3N8BqPpSzBNwV/G0Ukr+P/l3ivvJUE/Fa/CwbS6HesGNQ==",
+            "version": "0.16.47",
+            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+            "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
             "funding": [
                 "https://opencollective.com/katex",
                 "https://github.com/sponsors/katex"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "./dist/index.cjs.js"
     ],
     "files": [
-        "dist"
+        "dist",
+        "!dist/**/*.map"
     ],
     "publishConfig": {
         "access": "public"
@@ -49,7 +50,7 @@
         "codemirror-shiki": "^0.3.0",
         "evergreen-ui": "^7.1.9",
         "github-slugger": "^2.0.0",
-        "katex": "^0.16.11",
+        "katex": "^0.16.22",
         "react-markdown": "^9.0.1",
         "rehype-katex": "^7.0.0",
         "rehype-raw": "^7.0.0",


### PR DESCRIPTION
## Problem

**NOTIE-040:** `katex@0.16.11` is vulnerable to [GHSA-cg87-wmx4-v546](https://github.com/advisories/GHSA-cg87-wmx4-v546) — `\htmlData` does not validate attribute names, allowing XSS when rendering untrusted input with `trust: true` (fixed in katex 0.16.21). notie exposes KaTeX's `trust`/`htmlId` options (used for equation references), so this is squarely in the threat model.

**NOTIE-041:** `npm pack` shipped 50 `dist/**/*.map` files (~17 MB unpacked), producing a 6.6 MB tarball / 28.1 MB unpacked install for consumers who don't need library sourcemaps.

## Solution

- Bump `katex` to `^0.16.22` in `package.json`; lockfile resolves to `katex@0.16.47` (single deduped version — `rehype-katex` and `micromark-extension-math` both dedupe to it).
- Exclude sourcemaps from the published package via npm `files` negation: `["dist", "!dist/**/*.map"]`. Sourcemap **generation is unchanged** for local dev/builds.

**Lockfile diff scope (exact):** only two hunks, both katex —
1. root dependency range `"katex": "^0.16.11"` → `"^0.16.22"`
2. `node_modules/katex` entry: version/resolved/integrity `0.16.11` → `0.16.47`

No other lockfile entries touched (a plain `npm install` wanted to also rewrite unrelated `vitest`/`@esbuild/*` peer entries — that churn is pre-existing on this branch even with no package.json change, and was deliberately excluded). Validated with a clean `npm ci` against the edited lockfile.

## Tests

- `npm test` — 23 files / 148 tests passed (includes KaTeX math rendering + equation reference tests)
- `npm run lint` — clean
- `npm run build` — succeeds; sourcemaps still emitted to `dist/`
- `npx prettier --check .` — clean
- `npm ls katex` — single deduped `katex@0.16.47`; `node_modules/katex/package.json` confirms `0.16.47`
- `npm audit` — no katex findings remain
- `npm pack --dry-run` — 0 `.map` files in tarball

## Tarball size (npm pack --dry-run)

| | Before | After |
|---|---|---|
| Package size | 6.6 MB | **3.4 MB** |
| Unpacked size | 28.1 MB | **10.9 MB** |
| Total files | 128 | **78** |

## Risk

- **Low.** katex 0.16.x is semver-compatible; full test suite (incl. math rendering) passes on 0.16.47.
- The shipped JS still contains `//# sourceMappingURL=` comments pointing at maps that are no longer published. This is harmless — browsers/tools only fetch maps when devtools are open, and a 404 there is silently ignored. Build and tests confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)