### PR TITLE
fix: retry pending scroll until anchors exist; equation-env \nonumber; cache key uses resolved lang (NOTIE-044)

### DIFF
--- a/src/components/Notie.test.tsx
+++ b/src/components/Notie.test.tsx
@@ -5,12 +5,64 @@ import {
     waitFor,
     within,
 } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Notie from "./Notie";
 
 describe("Notie", () => {
     beforeEach(() => {
         window.history.replaceState(null, "", "/");
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("scrolls to a debounce-labeled equation anchor targeted by the URL hash", async () => {
+        // Equation ids (eqn-X.Y) are assigned by a coalesced DOM-labeling
+        // effect that trails the last progressive reveal by a short
+        // debounce, so the pending-scroll effect must retry until the
+        // anchor exists instead of giving up on its first run.
+        window.history.replaceState(null, "", "/#eqn-3.1");
+        const scrollSpy = vi.spyOn(HTMLElement.prototype, "scrollIntoView");
+
+        render(
+            <Notie
+                markdown={`# Demo
+
+## One
+
+First section.
+
+## Two
+
+Second section.
+
+## Three
+
+$$
+\\begin{equation} \\label{eq:last}
+z = 3
+\\end{equation}
+$$
+`}
+            />,
+        );
+
+        // The target lives in a not-yet-revealed section, and its id only
+        // appears after the post-reveal labeling debounce.
+        expect(document.getElementById("eqn-3.1")).toBeNull();
+
+        await waitFor(
+            () => {
+                expect(scrollSpy).toHaveBeenCalled();
+            },
+            { timeout: 3000 },
+        );
+
+        const scrolledElement = scrollSpy.mock
+            .contexts[0] as unknown as HTMLElement;
+        expect(scrolledElement.id).toBe("eqn-3.1");
+        expect(window.location.hash).toBe("#eqn-3.1");
     });
 
     it("renders markdown, TOC, equations, blockquote references, and custom components", async () => {

--- a/src/components/Notie.tsx
+++ b/src/components/Notie.tsx
@@ -169,14 +169,42 @@ const Notie: React.FC<NotieProps> = ({
     useEffect(() => {
         if (!pendingScrollId || typeof window === "undefined") return;
 
-        const target = document.getElementById(pendingScrollId);
-        if (!target) return;
+        const scrollToTarget = (target: Element) => {
+            target.scrollIntoView();
+            if (window.location.hash !== `#${pendingScrollId}`) {
+                window.history.pushState(null, "", `#${pendingScrollId}`);
+            }
+            setPendingScrollId(null);
+        };
 
-        target.scrollIntoView();
-        if (window.location.hash !== `#${pendingScrollId}`) {
-            window.history.pushState(null, "", `#${pendingScrollId}`);
+        const target = document.getElementById(pendingScrollId);
+        if (target) {
+            scrollToTarget(target);
+            return;
         }
-        setPendingScrollId(null);
+
+        // The target may not exist yet even after every section has been
+        // revealed: anchor ids such as `eqn-X.Y` are assigned by the
+        // coalesced DOM-labeling effects above, which trail the final
+        // `renderedSectionCount` update by a short debounce. Since this
+        // effect gets no further dependency changes at that point, poll
+        // briefly for the anchor instead of giving up, bounded so an id
+        // that never materializes cannot poll forever.
+        const RETRY_INTERVAL_MS = 80;
+        const RETRY_TIMEOUT_MS = 2000;
+        const deadline = Date.now() + RETRY_TIMEOUT_MS;
+        let timeoutId: number | undefined;
+        const retry = () => {
+            const retryTarget = document.getElementById(pendingScrollId);
+            if (retryTarget) {
+                scrollToTarget(retryTarget);
+                return;
+            }
+            if (Date.now() >= deadline) return;
+            timeoutId = window.setTimeout(retry, RETRY_INTERVAL_MS);
+        };
+        timeoutId = window.setTimeout(retry, RETRY_INTERVAL_MS);
+        return () => window.clearTimeout(timeoutId);
     }, [pendingScrollId, renderedSectionCount]);
 
     // Effect to observe headings and update activeId. Coalesced so that a

--- a/src/utils/MarkdownProcessor.test.ts
+++ b/src/utils/MarkdownProcessor.test.ts
@@ -589,6 +589,78 @@ $$
         expect(result.equationMapping["eq:after"].equationNumber).toBe("1.2");
     });
 
+    it("warns and skips mapping for an equation environment with \\label and \\nonumber", () => {
+        const errorSpy = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+        const markdown = `# Title
+
+## Section
+
+$$
+\\begin{equation} \\label{eq:ghost} \\nonumber
+a = 1
+\\end{equation}
+$$
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.equationMapping["eq:ghost"]).toBeUndefined();
+        expect(errorSpy).toHaveBeenCalledWith(
+            expect.stringContaining("eq:ghost"),
+        );
+        errorSpy.mockRestore();
+    });
+
+    it("does not let a \\nonumber equation environment consume a number", () => {
+        const markdown = `# Title
+
+## Section
+
+$$
+\\begin{equation} \\nonumber
+a = 1
+\\end{equation}
+$$
+
+$$
+\\begin{equation} \\label{eq:real}
+b = 2
+\\end{equation}
+$$
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        // KaTeX gives the \nonumber equation no number, so eq:real is the
+        // first numbered equation: 1.1, not 1.2.
+        expect(result.equationMapping["eq:real"].equationNumber).toBe("1.1");
+    });
+
+    it("treats \\notag in an equation environment the same as \\nonumber", () => {
+        const markdown = `# Title
+
+## Section
+
+$$
+\\begin{equation} \\notag
+a = 1
+\\end{equation}
+$$
+
+$$
+\\begin{equation} \\label{eq:real}
+b = 2
+\\end{equation}
+$$
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.equationMapping["eq:real"].equationNumber).toBe("1.1");
+    });
+
     it("skips a nested multi-line block marked \\nonumber", () => {
         const markdown = `# Title
 

--- a/src/utils/MarkdownProcessor.ts
+++ b/src/utils/MarkdownProcessor.ts
@@ -266,6 +266,16 @@ export class MarkdownProcessor {
         sectionIndex: number,
         currEquationNumber: number,
     ): number {
+        // KaTeX assigns no equation number (no `.eqn-num` span) to an
+        // equation environment containing \nonumber or \notag, so it must
+        // not consume a number here either — otherwise every mapping after
+        // it drifts off by one from the DOM numbering (same rule as the
+        // align path above).
+        if (this.isUnnumberedLine(equation)) {
+            this.warnIfLabeledUnnumbered(equation);
+            return currEquationNumber;
+        }
+
         const label = equation.match(/\\label\{(.*?)\}/g)?.[0];
         if (label) {
             // extract between \begin{equation} and \end{equation}

--- a/src/utils/shikiHighlighter.test.ts
+++ b/src/utils/shikiHighlighter.test.ts
@@ -93,6 +93,22 @@ describe("highlightWithCache", () => {
         expect(codeToHtml).toHaveBeenCalledTimes(2);
     });
 
+    it("shares one cache entry across language aliases", async () => {
+        const first = await highlightWithCache(
+            "print('hi')",
+            "py",
+            "github-dark",
+        );
+        const second = await highlightWithCache(
+            "print('hi')",
+            "python",
+            "github-dark",
+        );
+
+        expect(first).toBe(second);
+        expect(codeToHtml).toHaveBeenCalledTimes(1);
+    });
+
     it("re-highlights when the code differs", async () => {
         await highlightWithCache("a", "python", "github-dark");
         await highlightWithCache("b", "python", "github-dark");

--- a/src/utils/shikiHighlighter.ts
+++ b/src/utils/shikiHighlighter.ts
@@ -62,7 +62,8 @@ export function __configureHighlightCacheForTests(
 }
 
 /**
- * Highlight `code`, memoizing the resulting HTML per (theme, lang, code).
+ * Highlight `code`, memoizing the resulting HTML per (theme, resolved
+ * lang, code).
  * Static code blocks remount on section re-renders with identical inputs,
  * so caching avoids repeating the dominant codeToHtml cost.
  */
@@ -71,7 +72,10 @@ export async function highlightWithCache(
     lang: string,
     theme: string,
 ): Promise<string> {
-    const key = `${theme}|${lang}|${code}`;
+    // Key on the resolved language so aliases (e.g. "py" and "python")
+    // share a cache entry instead of highlighting the same code twice.
+    const resolvedLang = resolveLanguage(lang);
+    const key = `${theme}|${resolvedLang}|${code}`;
     const cached = highlightCache.get(key);
     if (cached !== undefined) {
         // Refresh recency: move the entry to the end of iteration order.
@@ -81,7 +85,7 @@ export async function highlightWithCache(
     }
     const highlighter = await getHighlighter();
     const html = highlighter.codeToHtml(code, {
-        lang: resolveLanguage(lang),
+        lang: resolvedLang,
         theme: theme as BundledTheme,
     });
     highlightCache.set(key, html);


### PR DESCRIPTION
## Problem

Review NOTIE-044 found three regressions:

1. **(HIGH) Pending-scroll vs debounced equation labeling race.** `Notie.tsx`'s pending-scroll effect runs on `[pendingScrollId, renderedSectionCount]` and silently gave up when `document.getElementById(pendingScrollId)` returned null. Since PR #75, equation ids (`eqn-X.Y`) are assigned by `labelEquationNumbers` inside `useCoalescedRevealEffect` with a 50ms trailing debounce — so after `requestRenderAll` reveals all sections, the scroll effect fires *before* the ids exist and never retries (`renderedSectionCount` stops changing). Hash/TOC navigation to an equation anchor was permanently lost.
2. **(MED) `processEquationEnvironment` ignores `\nonumber`/`\notag`.** PR #67 fixed the align path with `isUnnumberedLine`, but the `equation` path still unconditionally incremented `currEquationNumber`, drifting every subsequent mapping off by one from KaTeX's DOM numbering.
3. **(LOW) `highlightWithCache` keys on the raw language.** The key used `lang` as passed while highlighting used `resolveLanguage(lang)`, so aliases (`py` vs `python`) produced duplicate cache entries and redundant `codeToHtml` calls.

## Solution

- **Notie.tsx:** when the target is absent, the pending-scroll effect now polls `getElementById` on an 80ms interval, bounded to 2s, and scrolls (plus pushes the hash) once the anchor appears. The timer is cleaned up on unmount / `pendingScrollId` change, and the immediate path (target already present → scroll synchronously) is unchanged.
- **MarkdownProcessor.ts:** `processEquationEnvironment` applies the same rule as the align path via the existing `isUnnumberedLine`/`warnIfLabeledUnnumbered` helpers: an equation environment containing `\nonumber`/`\notag` consumes no number, and a `\label` on such an environment is skipped with the same style of `console.error` warning.
- **shikiHighlighter.ts:** the cache key is now built from `resolveLanguage(lang)` (the same value passed to `codeToHtml`), so aliases share one entry.

## Tests

- **Fix 1:** new component test renders a 3-section doc with a labeled equation in the last section and `window.location.hash = "#eqn-3.1"` set before render; asserts the anchor does not exist initially, then waits for `scrollIntoView` to be called on the element with id `eqn-3.1` and for the hash to be preserved. **Verified to FAIL against the unfixed `Notie.tsx`** (stashed the fix; the test times out because the scroll never happens) and pass with the fix.
- **Fix 2:** new MarkdownProcessor tests: equation env with `\label` + `\nonumber` → no mapping entry + `console.error`; `\nonumber` (and `\notag`) equation env followed by a labeled one → the labeled equation maps to `1.1`, not `1.2`.
- **Fix 3:** new shikiHighlighter test: highlighting the same code/theme with `"py"` then `"python"` performs exactly 1 underlying `codeToHtml` call and returns identical HTML.

Checks: `npm test` (156 tests, run twice for flake confidence), `npm run lint`, `npm run build`, `npx prettier --check .` — all green. No `package-lock.json` changes.

## Risk

- The retry loop only runs while a `pendingScrollId` is set and is bounded (2s), so an id that never materializes cannot poll forever; behavior for already-present anchors is byte-identical.
- The `\nonumber` equation-env rule mirrors KaTeX's actual rendering (no `.eqn-num` span is emitted), matching the already-shipped align-path semantics.
- The cache-key change can only *increase* hit rate; the resolved language is exactly what the highlighter receives, so entries cannot collide across genuinely different languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)