### PR TITLE
fix: empty-TOC guard, nested blockquote refs in previews, GFM/table/footnote polish, docs limitations (NOTIE-043)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Please keep the following in mind when using **notie**:
 - **`tikz` blocks load a third-party engine.** TikZ diagrams are rendered by the [TikZJax](https://github.com/artisticat1/obsidian-tikzjax) engine, whose script and stylesheet are fetched at runtime from a pinned third-party URL and executed in the page.
 - **`desmos` blocks load the Desmos API script.** Graphs are rendered by loading the [Desmos](https://www.desmos.com/) calculator API script from Desmos servers at runtime.
 
+## Limitations
+
+- **One themed `Notie` instance per page.** Theming is applied by setting CSS variables (e.g. `--blog-background-color`, `--blog-text-color`) globally on the document root (`:root`). If you render multiple `Notie` components on the same page with different `theme` or `config.theme` values, they will overwrite each other's variables and all instances end up styled by whichever one applied its theme last. Multiple instances are fine as long as they share the same theme configuration.
+
 ## Configuration reference
 
 The `config` prop accepts a `NotieConfig` object. All fields are optional; unspecified fields fall back to the selected theme's defaults.

--- a/src/components/BlockquoteReference.test.tsx
+++ b/src/components/BlockquoteReference.test.tsx
@@ -92,4 +92,45 @@ describe("BlockquoteReference", () => {
         });
         expect(screen.queryByText(/A reusable definition/)).toBeNull();
     });
+
+    it("renders nested #bqref- links inside preview cards as styled references without nested previews", async () => {
+        const nestedMapping: BlockquoteMapping = {
+            ...blockquoteMapping,
+            "thm:second": {
+                blockquoteNumber: "1.2",
+                blockquoteType: "theorem",
+                blockquoteContent:
+                    "Follows from [the definition](#bqref-def:first).",
+            },
+        };
+
+        const { baseElement } = render(
+            <BlockquoteReference
+                href="#bqref-thm:second"
+                blockquoteMapping={nestedMapping}
+                equationMapping={equationMapping}
+                previewBlockquotes
+            />,
+        );
+
+        fireEvent.mouseEnter(screen.getByRole("link", { name: "Theorem 1.2" }));
+
+        // The nested reference resolves to a BlockquoteReference link with
+        // the resolved label, not a plain "the definition" anchor.
+        const nestedLink = await screen.findByRole("link", {
+            name: "Definition 1.1",
+        });
+        expect(nestedLink).toHaveAttribute("href", "#def:first");
+        expect(screen.queryByText("the definition")).toBeNull();
+
+        // The nested reference must not spawn its own preview card on hover
+        // (previewBlockquotes is disabled for nested references).
+        fireEvent.mouseEnter(nestedLink);
+        await waitFor(() => {
+            expect(nestedLink).toHaveTextContent("Definition 1.1");
+        });
+        expect(baseElement.textContent?.includes("A reusable definition")).toBe(
+            false,
+        );
+    });
 });

--- a/src/components/BlockquoteReference.tsx
+++ b/src/components/BlockquoteReference.tsx
@@ -77,6 +77,7 @@ const BlockquoteReference = ({
                     label={label}
                     content={blockquoteContent}
                     blockquoteType={blockquoteType}
+                    blockquoteMapping={blockquoteMapping}
                     equationMapping={equationMapping}
                     previewEquations={previewEquations}
                 />
@@ -101,12 +102,14 @@ const BlockquoteCard = ({
     label,
     content,
     blockquoteType,
+    blockquoteMapping,
     equationMapping,
     previewEquations,
 }: {
     label: string;
     content: string;
     blockquoteType: string;
+    blockquoteMapping: BlockquoteMapping;
     equationMapping: EquationMapping;
     previewEquations?: boolean;
 }) => {
@@ -133,6 +136,21 @@ const BlockquoteCard = ({
                     );
                 }
 
+                if (href.startsWith("#bqref-")) {
+                    // Render nested blockquote references as styled links
+                    // without their own preview so tooltips never nest
+                    // (and never recurse) inside a preview card.
+                    return (
+                        <BlockquoteReference
+                            href={href}
+                            blockquoteMapping={blockquoteMapping}
+                            equationMapping={equationMapping}
+                            previewBlockquotes={false}
+                            previewEquations={previewEquations}
+                        />
+                    );
+                }
+
                 return (
                     <a href={href} {...props}>
                         {children}
@@ -140,7 +158,7 @@ const BlockquoteCard = ({
                 );
             },
         }),
-        [equationMapping, previewEquations],
+        [blockquoteMapping, equationMapping, previewEquations],
     );
 
     return (

--- a/src/components/Notie.test.tsx
+++ b/src/components/Notie.test.tsx
@@ -532,4 +532,17 @@ $\\href{https://example.com}{good}$
             container.querySelector('a[href="https://example.com"]'),
         ).not.toBeNull();
     });
+
+    it("does not render the TOC for empty markdown", () => {
+        render(<Notie markdown="" />);
+
+        expect(screen.queryByRole("navigation")).toBeNull();
+    });
+
+    it("does not render the TOC for title-only documents", () => {
+        render(<Notie markdown={"# Only a Title\n\nSome body text.\n"} />);
+
+        expect(screen.getByText("Some body text.")).toBeInTheDocument();
+        expect(screen.queryByRole("navigation")).toBeNull();
+    });
 });

--- a/src/components/Notie.tsx
+++ b/src/components/Notie.tsx
@@ -297,16 +297,15 @@ const Notie: React.FC<NotieProps> = ({
         renderedSectionCount,
     );
 
+    // Skip the TOC column entirely when there is nothing to list (empty
+    // markdown or title-only documents), so a bare "Contents" heading never
+    // renders next to the note.
+    const showToc = config.showTableOfContents && tocEntries.length > 0;
+
     return (
         <Pane className={styles["notie-container"]}>
-            <Pane
-                className={
-                    config.showTableOfContents
-                        ? styles["mw-page-container-inner"]
-                        : ""
-                }
-            >
-                {config.showTableOfContents && (
+            <Pane className={showToc ? styles["mw-page-container-inner"] : ""}>
+                {showToc && (
                     <Pane className={styles["vector-column-start"]}>
                         <NoteToc
                             tocEntries={tocEntries}

--- a/src/styles/Notie.module.css
+++ b/src/styles/Notie.module.css
@@ -65,6 +65,9 @@
     font-family: var(--blog-font-family);
     color: var(--blog-text-color);
     overflow-x: hidden;
+    /* Long unbreakable tokens (URLs, hashes) wrap instead of clipping
+       under the overflow-x: hidden above. */
+    overflow-wrap: anywhere;
 }
 
 /* Heading colors */
@@ -132,6 +135,13 @@
 }
 
 /* Table colors */
+.blog-content table {
+    /* Body cells read the theme background so tables look consistent even
+       inside surfaces with their own background (e.g. collapse sections),
+       in both light and dark appearances. */
+    background-color: var(--blog-background-color);
+}
+
 .blog-content th {
     background-color: var(--blog-table-background-color);
 }
@@ -229,6 +239,22 @@
     margin: 16px auto;
 }
 
+/* GFM task list styles (remark-gfm emits .task-list-item on the <li> and
+   .contains-task-list on the list): drop the list marker so checkboxes do
+   not get a double bullet, and align the checkbox with the text. */
+.blog-content ul:global(.contains-task-list) {
+    padding-left: 1em;
+}
+
+.blog-content li:global(.task-list-item) {
+    list-style-type: none;
+}
+
+.blog-content li:global(.task-list-item) input[type="checkbox"] {
+    margin-right: 0.4em;
+    vertical-align: middle;
+}
+
 /* a tag styles for reference and katex */
 
 .blog-content a[data-footnote-ref] {
@@ -237,6 +263,14 @@
 
 .blog-content a[data-footnote-backref] {
     text-decoration: none;
+}
+
+/* GFM footnotes section */
+.blog-content section[data-footnotes] {
+    margin-top: 2em;
+    border-top: 1px solid var(--blog-table-border-color);
+    font-size: 0.9em;
+    color: var(--blog-caption-color);
 }
 
 /* Collapse Section Styles */


### PR DESCRIPTION
## Problem

A bundle of small rendering polish issues:

1. **Empty TOC**: `Notie` rendered the TOC column whenever `config.showTableOfContents` was true, so empty or title-only markdown showed a bare "Contents" heading next to nothing.
2. **Nested blockquote refs in previews**: `BlockquoteCard`'s `a` component map handled `#pre-eqn-` links but not `#bqref-`, so a blockquote reference inside another blockquote's hover preview rendered as a plain unresolved anchor ("the definition" instead of "Definition 1.1").
3. **Table dark mode**: `th` reads `--blog-table-background-color` but `td` had no background, so table bodies were transparent and picked up whatever surface sat behind them (e.g. tinted collapse sections) in dark mode.
4. **GFM task lists**: no styling for `remark-gfm` task lists, so checkboxes rendered with a double marker (bullet + checkbox).
5. **GFM footnotes**: `section[data-footnotes]` had no styling and blended into body text.
6. **Long unbreakable tokens**: `.blog-content` uses `overflow-x: hidden`, so long URLs/hashes in paragraphs were silently clipped.
7. **Docs**: the single-instance-per-page theming constraint was undocumented.

## Solution

- `src/components/Notie.tsx`: gate the TOC column on `config.showTableOfContents && tocEntries.length > 0` (grid layout class is skipped too, so content takes the full width).
- `src/components/BlockquoteReference.tsx`: `BlockquoteCard` now receives `blockquoteMapping` and renders nested `#bqref-` links as `BlockquoteReference` with `previewBlockquotes={false}` — a resolved, styled link without a nested tooltip, so previews can never nest or recurse.
- `src/styles/Notie.module.css`:
  - Tables: set `background-color: var(--blog-background-color)` on `.blog-content table` rather than on every `td`. This keeps header cells on `--blog-table-background-color` while body cells read the theme background, which is the cleanest way to make both light and dark appearances consistent without introducing a new variable or per-cell opacity hacks.
  - Task lists: `mdast-util-to-hast` (used by remark-gfm via react-markdown) emits `contains-task-list` on the list and `task-list-item` on the `li` (verified in `node_modules/mdast-util-to-hast/lib/handlers/list.js` / `list-item.js`); rules target those classes to drop the list marker and align the checkbox.
  - Footnotes: `section[data-footnotes]` gets a top border (`--blog-table-border-color`), `font-size: 0.9em`, and the muted `--blog-caption-color`.
  - Overflow: `overflow-wrap: anywhere` on `.blog-content` so unbreakable tokens wrap instead of clipping.
- `README.md`: new "Limitations" section documenting that theming sets CSS variables globally on `:root`, so multiple `Notie` instances with different themes on one page conflict (last one wins).

## Tests

- New: empty markdown renders no TOC (`queryByRole("navigation")` null); title-only document renders content but no TOC.
- New: nested `#bqref-` inside a preview card resolves to a `BlockquoteReference` link (`Definition 1.1` -> `#def:first`) and hovering the nested link does not spawn a second preview card.
- Full suite: 151 tests / 23 files pass; `npm run lint`, `npm run build`, and `npx prettier --check .` clean.

## Risk

Low. CSS changes are scoped to `.blog-content` / footnote-and-task-list selectors; the table background change is the most visible one (table bodies now paint the theme background instead of being transparent). The nested-reference change only affects `#bqref-` anchors inside preview cards, which previously rendered as dead-looking plain links. TOC guard only changes behavior for documents that had no TOC entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)