### PR TITLE
feat: configurable Desmos API key (NOTIE-V01)

### DIFF
--- a/src/components/DesmosGraph.test.tsx
+++ b/src/components/DesmosGraph.test.tsx
@@ -96,6 +96,91 @@ describe("DesmosGraph", () => {
         expect(destroy).toHaveBeenCalledTimes(1);
     });
 
+    // Intercept injected <script> tags: record their src and fire onload
+    // (defining window.Desmos just before, like the real script would).
+    function interceptScriptInjection() {
+        const scriptSrcs: string[] = [];
+        const appendChild = vi
+            .spyOn(document.head, "appendChild")
+            .mockImplementation(((node: Node) => {
+                if (node instanceof HTMLScriptElement) {
+                    scriptSrcs.push(node.src);
+                    setTimeout(() => {
+                        stubDesmos();
+                        node.onload?.(new Event("load"));
+                    }, 0);
+                }
+                return node;
+            }) as typeof document.head.appendChild);
+        return { scriptSrcs, appendChild };
+    }
+
+    it("loads the Desmos script with the default demo API key", async () => {
+        const DesmosGraph = await importDesmosGraph();
+        const { scriptSrcs, appendChild } = interceptScriptInjection();
+
+        render(<DesmosGraph graphScript="y=x" />);
+
+        await waitFor(() => {
+            expect(scriptSrcs).toHaveLength(1);
+        });
+        expect(scriptSrcs[0]).toBe(
+            "https://www.desmos.com/api/v1.9/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6",
+        );
+
+        appendChild.mockRestore();
+    });
+
+    it("loads the Desmos script with a custom API key", async () => {
+        const DesmosGraph = await importDesmosGraph();
+        const { scriptSrcs, appendChild } = interceptScriptInjection();
+
+        render(<DesmosGraph graphScript="y=x" apiKey="my-custom-key" />);
+
+        await waitFor(() => {
+            expect(scriptSrcs).toHaveLength(1);
+        });
+        expect(scriptSrcs[0]).toBe(
+            "https://www.desmos.com/api/v1.9/calculator.js?apiKey=my-custom-key",
+        );
+
+        appendChild.mockRestore();
+    });
+
+    it("caches the script loader per API key", async () => {
+        const DesmosGraph = await importDesmosGraph();
+
+        // Record injected scripts but never fire onload, so the loader
+        // promises stay pending and caching behavior is observable.
+        const scriptSrcs: string[] = [];
+        const appendChild = vi
+            .spyOn(document.head, "appendChild")
+            .mockImplementation(((node: Node) => {
+                if (node instanceof HTMLScriptElement) {
+                    scriptSrcs.push(node.src);
+                }
+                return node;
+            }) as typeof document.head.appendChild);
+
+        render(
+            <>
+                <DesmosGraph graphScript="y=x" apiKey="key-a" />
+                <DesmosGraph graphScript="y=x^2" apiKey="key-a" />
+                <DesmosGraph graphScript="y=x^3" apiKey="key-b" />
+            </>,
+        );
+
+        await waitFor(() => {
+            expect(scriptSrcs).toHaveLength(2);
+        });
+        expect(scriptSrcs).toEqual([
+            "https://www.desmos.com/api/v1.9/calculator.js?apiKey=key-a",
+            "https://www.desmos.com/api/v1.9/calculator.js?apiKey=key-b",
+        ]);
+
+        appendChild.mockRestore();
+    });
+
     it("renders a fallback when the Desmos script fails to load", async () => {
         const DesmosGraph = await importDesmosGraph();
 

--- a/src/components/DesmosGraph.test.tsx
+++ b/src/components/DesmosGraph.test.tsx
@@ -1,12 +1,12 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// DesmosGraph caches its script-loader promise at module scope, so import a
+// DesmosGraph caches its script-loader promises at module scope, so import a
 // fresh copy for each test to avoid state leaking between tests.
 async function importDesmosGraph() {
     vi.resetModules();
     const module = await import("./DesmosGraph");
-    return module.default;
+    return module;
 }
 
 function stubDesmos() {
@@ -35,7 +35,7 @@ describe("DesmosGraph", () => {
 
     it("creates the calculator without inverted colors by default", async () => {
         const { GraphingCalculator } = stubDesmos();
-        const DesmosGraph = await importDesmosGraph();
+        const { default: DesmosGraph } = await importDesmosGraph();
 
         render(<DesmosGraph graphScript="y=x" />);
 
@@ -50,7 +50,7 @@ describe("DesmosGraph", () => {
 
     it("creates the calculator with inverted colors in dark mode", async () => {
         const { GraphingCalculator } = stubDesmos();
-        const DesmosGraph = await importDesmosGraph();
+        const { default: DesmosGraph } = await importDesmosGraph();
 
         render(<DesmosGraph graphScript="y=x" appearance="dark" />);
 
@@ -65,7 +65,7 @@ describe("DesmosGraph", () => {
 
     it("sets one expression per non-empty line", async () => {
         const { setExpression } = stubDesmos();
-        const DesmosGraph = await importDesmosGraph();
+        const { default: DesmosGraph } = await importDesmosGraph();
 
         render(<DesmosGraph graphScript={"y=x\n\ny=x^2"} />);
 
@@ -84,7 +84,7 @@ describe("DesmosGraph", () => {
 
     it("destroys the calculator on unmount", async () => {
         const { GraphingCalculator, destroy } = stubDesmos();
-        const DesmosGraph = await importDesmosGraph();
+        const { default: DesmosGraph } = await importDesmosGraph();
 
         const { unmount } = render(<DesmosGraph graphScript="y=x" />);
 
@@ -116,7 +116,8 @@ describe("DesmosGraph", () => {
     }
 
     it("loads the Desmos script with the default demo API key", async () => {
-        const DesmosGraph = await importDesmosGraph();
+        const { default: DesmosGraph, DEFAULT_DESMOS_API_KEY } =
+            await importDesmosGraph();
         const { scriptSrcs, appendChild } = interceptScriptInjection();
 
         render(<DesmosGraph graphScript="y=x" />);
@@ -125,14 +126,14 @@ describe("DesmosGraph", () => {
             expect(scriptSrcs).toHaveLength(1);
         });
         expect(scriptSrcs[0]).toBe(
-            "https://www.desmos.com/api/v1.9/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6",
+            `https://www.desmos.com/api/v1.9/calculator.js?apiKey=${DEFAULT_DESMOS_API_KEY}`,
         );
 
         appendChild.mockRestore();
     });
 
     it("loads the Desmos script with a custom API key", async () => {
-        const DesmosGraph = await importDesmosGraph();
+        const { default: DesmosGraph } = await importDesmosGraph();
         const { scriptSrcs, appendChild } = interceptScriptInjection();
 
         render(<DesmosGraph graphScript="y=x" apiKey="my-custom-key" />);
@@ -148,7 +149,7 @@ describe("DesmosGraph", () => {
     });
 
     it("caches the script loader per API key", async () => {
-        const DesmosGraph = await importDesmosGraph();
+        const { default: DesmosGraph } = await importDesmosGraph();
 
         // Record injected scripts but never fire onload, so the loader
         // promises stay pending and caching behavior is observable.
@@ -182,7 +183,7 @@ describe("DesmosGraph", () => {
     });
 
     it("renders a fallback when the Desmos script fails to load", async () => {
-        const DesmosGraph = await importDesmosGraph();
+        const { default: DesmosGraph } = await importDesmosGraph();
 
         // No window.Desmos stub: the component injects a <script> tag and
         // waits for onload/onerror. Simulate a network failure.

--- a/src/components/DesmosGraph.tsx
+++ b/src/components/DesmosGraph.tsx
@@ -5,16 +5,25 @@ import styles from "../styles/Notie.module.css";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const Desmos: any;
 
-let desmosScriptPromise: Promise<void> | null = null;
+/**
+ * Desmos's public demo API key. Calculators loaded with it log a warning
+ * that it is not licensed for commercial use; consumers can supply their
+ * own key via `NotieConfig.desmosApiKey`.
+ */
+export const DEFAULT_DESMOS_API_KEY = "dcb31709b452b1cf9dc26972add0fda6";
 
-function loadDesmosScript(): Promise<void> {
+// One cached loader promise per API key: different keys use different
+// script URLs, so they must not share a cache entry.
+const desmosScriptPromises = new Map<string, Promise<void>>();
+
+function loadDesmosScript(apiKey: string): Promise<void> {
     if (typeof Desmos !== "undefined") return Promise.resolve();
 
-    if (!desmosScriptPromise) {
-        desmosScriptPromise = new Promise<void>((resolve, reject) => {
+    let scriptPromise = desmosScriptPromises.get(apiKey);
+    if (!scriptPromise) {
+        scriptPromise = new Promise<void>((resolve, reject) => {
             const scriptEl = document.createElement("script");
-            scriptEl.src =
-                "https://www.desmos.com/api/v1.9/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6";
+            scriptEl.src = `https://www.desmos.com/api/v1.9/calculator.js?apiKey=${encodeURIComponent(apiKey)}`;
             scriptEl.async = true;
             scriptEl.onload = () => resolve();
             scriptEl.onerror = () =>
@@ -22,22 +31,29 @@ function loadDesmosScript(): Promise<void> {
             document.head.appendChild(scriptEl);
         }).catch((error) => {
             // Do not cache the rejection, so the next mount retries.
-            desmosScriptPromise = null;
+            desmosScriptPromises.delete(apiKey);
             throw error;
         });
+        desmosScriptPromises.set(apiKey, scriptPromise);
     }
 
-    return desmosScriptPromise;
+    return scriptPromise;
 }
 
 export interface DesmosGraphProps {
     graphScript: string;
     appearance?: "light" | "dark";
+    /**
+     * Desmos calculator API key. Defaults to the built-in demo key, which
+     * logs a warning that it is not licensed for commercial use.
+     */
+    apiKey?: string;
 }
 
 const DesmosGraph = ({
     graphScript,
     appearance = "light",
+    apiKey = DEFAULT_DESMOS_API_KEY,
 }: DesmosGraphProps) => {
     const calculatorRef = useRef<HTMLDivElement | null>(null);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -49,7 +65,7 @@ const DesmosGraph = ({
 
         setLoadFailed(false);
 
-        loadDesmosScript()
+        loadDesmosScript(apiKey)
             .then(() => {
                 if (cancelled) return;
                 if (calculatorRef.current && !calculatorInstance.current) {
@@ -72,7 +88,7 @@ const DesmosGraph = ({
             calculatorInstance.current = null;
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [appearance]);
+    }, [appearance, apiKey]);
 
     // Update the calculator when graphScript changes
     useEffect(() => {

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -257,6 +257,7 @@ const MarkdownRenderer: React.FC<{
                                     <DesmosGraph
                                         graphScript={code}
                                         appearance={config.theme.appearance}
+                                        apiKey={config.desmosApiKey}
                                     />
                                 </LazyRender>
                             );
@@ -331,6 +332,7 @@ const MarkdownRenderer: React.FC<{
             [
                 blockquoteMapping,
                 config.codeRunnerUrl,
+                config.desmosApiKey,
                 config.previewBlockquotes,
                 config.previewEquations,
                 config.theme.appearance,

--- a/src/config/NotieConfig.tsx
+++ b/src/config/NotieConfig.tsx
@@ -48,6 +48,12 @@ export interface NotieConfig {
     fontSize?: CSSStyleDeclaration["fontSize"];
     /** Base URL of the code-runner service used by executable code blocks. */
     codeRunnerUrl?: string;
+    /**
+     * Desmos calculator API key used by ```desmos code blocks. Defaults to
+     * the built-in demo key, which logs a warning that it is not licensed
+     * for commercial use.
+     */
+    desmosApiKey?: string;
     theme?: Theme;
 }
 

--- a/src/utils/MarkdownProcessor.test.ts
+++ b/src/utils/MarkdownProcessor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { MarkdownProcessor } from "./MarkdownProcessor";
 import { FullNotieConfig } from "../config/NotieConfig";
+import { DEFAULT_DESMOS_API_KEY } from "../components/DesmosGraph";
 
 const config: FullNotieConfig = {
     showTableOfContents: true,
@@ -9,7 +10,7 @@ const config: FullNotieConfig = {
     tocTitle: "Contents",
     fontSize: "1rem",
     codeRunnerUrl: "https://api.brandonyifanyang.com",
-    desmosApiKey: "dcb31709b452b1cf9dc26972add0fda6",
+    desmosApiKey: DEFAULT_DESMOS_API_KEY,
     theme: {
         appearance: "light",
         backgroundColor: "#fff",

--- a/src/utils/MarkdownProcessor.test.ts
+++ b/src/utils/MarkdownProcessor.test.ts
@@ -9,6 +9,7 @@ const config: FullNotieConfig = {
     tocTitle: "Contents",
     fontSize: "1rem",
     codeRunnerUrl: "https://api.brandonyifanyang.com",
+    desmosApiKey: "dcb31709b452b1cf9dc26972add0fda6",
     theme: {
         appearance: "light",
         backgroundColor: "#fff",

--- a/src/utils/useNotieConfig.ts
+++ b/src/utils/useNotieConfig.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from "react";
 import { DEFAULT_CODE_RUNNER_URL } from "../service/api";
+import { DEFAULT_DESMOS_API_KEY } from "../components/DesmosGraph";
 import {
     FullNotieConfig,
     FullTheme,
@@ -192,6 +193,7 @@ const defaultNotieConfig: FullNotieConfig = {
     tocTitle: "Contents",
     fontSize: "1rem",
     codeRunnerUrl: DEFAULT_CODE_RUNNER_URL,
+    desmosApiKey: DEFAULT_DESMOS_API_KEY,
     theme: defaultTheme,
 };
 


### PR DESCRIPTION
## Problem

`DesmosGraph` hardcodes Desmos's public demo API key in the injected script URL, so every consumer's calculator loads with a key that is not licensed for commercial use (and logs a warning saying so). There was no way to supply a production key. Flagged as a NEW-FINDING in the visual review of PR #63: https://github.com/branyang02/notie/pull/63#issuecomment-5017184338

## Solution

- `NotieConfig` gains an optional `desmosApiKey` (JSDoc documents the demo-key default and its commercial-use warning).
- `defaultNotieConfig` defaults it to the existing demo key via a new exported `DEFAULT_DESMOS_API_KEY` constant in `DesmosGraph.tsx`.
- `DesmosGraph` accepts an optional `apiKey` prop; the module-level script loader now caches its promise per API key (`Map`), since different keys mean different script URLs. Rejections are still evicted so the next mount retries.
- `MarkdownRenderer` threads `config.desmosApiKey` to `DesmosGraph` (added to the `components` useMemo deps).

Default behavior is byte-identical for consumers who don't set the key.

## Tests

Extended `src/components/DesmosGraph.test.tsx`:
- default renders inject the script with the current demo key
- a custom `apiKey` appears in the injected script src
- per-key caching: two graphs with the same key inject one script; a second key injects a second script

`npm test` (162 passed), `npm run lint`, `npm run build`, and `npx prettier --check .` are all green. No `package-lock.json` changes.

## Risk

Low. Additive, optional config; the only behavioral change with defaults is the loader caching per key instead of a single slot, which is equivalent when only one key is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)