### PR TITLE
fix: normalize single-line display-math environments so eqref anchors resolve (NOTIE-V02)

### DIFF
--- a/src/components/Notie.test.tsx
+++ b/src/components/Notie.test.tsx
@@ -125,6 +125,35 @@ See [definition](#bqref-def:first).
         expect(blockquoteReference).toHaveTextContent("Definition 1.1");
     });
 
+    it("renders single-line equation environments as display math with a working eqref anchor", () => {
+        const { container } = render(
+            <Notie
+                markdown={`# Demo
+
+## First Section
+
+$$\\begin{equation}\\label{eq:x} y = 1 \\end{equation}$$
+
+See $\\eqref{eq:x}$.
+`}
+            />,
+        );
+
+        // remark-math must parse the normalized equation as display math:
+        // a katex-display block and no red ParseError ("{equation} can be
+        // used only in display mode").
+        expect(container.querySelector(".katex-display")).toBeInTheDocument();
+        expect(container.querySelector(".katex-error")).not.toBeInTheDocument();
+
+        // The eqref link resolves to a real equation anchor in the DOM,
+        // not a dangling href.
+        const equationReference = container.querySelector('a[href="#eqn-1.1"]');
+        expect(equationReference).toHaveTextContent("(1.1)");
+        expect(container.querySelector("#eqn-1\\.1")).toHaveTextContent(
+            "(1.1)",
+        );
+    });
+
     it("renders equation references whose labels contain underscores", () => {
         const { container } = render(
             <Notie

--- a/src/utils/MarkdownProcessor.test.ts
+++ b/src/utils/MarkdownProcessor.test.ts
@@ -364,6 +364,72 @@ $$\\begin{equation}\\label{eq:a} x = 1 \\end{equation}$$
         );
     });
 
+    it("normalizes single-line equation environments to multi-line display math", () => {
+        const markdown = `# Title
+
+## Section
+
+$$\\begin{equation}\\label{eq:x} y = 1 \\end{equation}$$
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        // The label is mapped...
+        expect(result.equationMapping["eq:x"]).toBeDefined();
+        expect(result.equationMapping["eq:x"].equationNumber).toBe("1.1");
+        // ...and the returned content contains the canonical multi-line
+        // form (so remark-math parses it as display math), not the
+        // single-line form (which remark-math treats as inline math and
+        // KaTeX rejects with "{equation} can be used only in display
+        // mode").
+        expect(result.markdownContent).toContain(
+            "$$\n\\begin{equation}\\label{eq:x} y = 1 \\end{equation}\n$$",
+        );
+        expect(result.markdownContent).not.toContain(
+            "$$\\begin{equation}\\label{eq:x} y = 1 \\end{equation}$$",
+        );
+        expect(result.markdownContent).toBe(result.markdownSections.join(""));
+    });
+
+    it("normalizes single-line align environments to multi-line display math", () => {
+        const markdown = `# Title
+
+## Section
+
+$$\\begin{align}a &= 1 \\label{eq:a1} \\\\ b &= 2 \\label{eq:a2}\\end{align}$$
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        // Each align row is numbered exactly once, in order.
+        expect(result.equationMapping["eq:a1"].equationNumber).toBe("1.1");
+        expect(result.equationMapping["eq:a2"].equationNumber).toBe("1.2");
+        // The delimiters and rows land on their own lines.
+        expect(result.markdownContent).toContain(
+            "$$\n\\begin{align}\na &= 1 \\label{eq:a1} \\\\\nb &= 2 \\label{eq:a2}\n\\end{align}\n$$",
+        );
+        expect(result.markdownContent).not.toContain("$$\\begin{align}");
+    });
+
+    it("does not normalize single-line environments inside fenced code blocks", () => {
+        const singleLine =
+            "$$\\begin{equation}\\label{eq:in-code} y = 1 \\end{equation}$$";
+        const markdown = `# Title
+
+## Section
+
+\`\`\`tex
+${singleLine}
+\`\`\`
+`;
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.equationMapping).toEqual({});
+        // The code block content is restored verbatim, still single-line.
+        expect(result.markdownContent).toContain(singleLine);
+    });
+
     it("counts single-line and multi-line equations in document order", () => {
         const markdown = `# Title
 

--- a/src/utils/MarkdownProcessor.ts
+++ b/src/utils/MarkdownProcessor.ts
@@ -26,7 +26,14 @@ export class MarkdownProcessor {
             this.markdownContent,
         );
 
-        const sections = this.splitIntoSections(maskedText);
+        // Normalize single-line `$$\begin{...}...\end{...}$$` display
+        // environments into the canonical multi-line form BEFORE section
+        // splitting and equation scanning, so the renderer (remark-math)
+        // and the equation mapping agree on what is display math.
+        const normalizedText =
+            this.normalizeSingleLineDisplayEnvironments(maskedText);
+
+        const sections = this.splitIntoSections(normalizedText);
         let processedSections = sections.map((section, i) => {
             section = i === 0 ? section : this.wrapInDiv(section, i); // Do not process the first section under Title
             return this.processSection(section, i);
@@ -70,6 +77,48 @@ export class MarkdownProcessor {
                 const numbering = counters.slice(0, level + 1).join(".");
                 return `${hashes} ${numbering}&nbsp;&nbsp;&nbsp;${title}`;
             }),
+        );
+    }
+
+    /**
+     * Rewrites display-math environments written on a single line, e.g.
+     *
+     *     $$\begin{equation}\label{eq:a} y = 1 \end{equation}$$
+     *
+     * into the canonical multi-line form
+     *
+     *     $$
+     *     \begin{equation}\label{eq:a} y = 1 \end{equation}
+     *     $$
+     *
+     * remark-math v6 parses a one-line `$$...$$` as INLINE math, so KaTeX
+     * rejects the display-only `equation`/`align` environments with a red
+     * ParseError and never creates the `eqn-X.Y` anchor — while the
+     * equation scanner still maps the `\label`, leaving `\eqref` links
+     * dangling. Normalizing before section splitting and scanning keeps
+     * the renderer and the mapping in agreement. Multi-line forms are
+     * untouched, and this runs on MASKED text, so code blocks and HTML
+     * comments can never be corrupted.
+     */
+    private normalizeSingleLineDisplayEnvironments(content: string): string {
+        const singleLinePattern =
+            /^([ \t]*)\$\$[ \t]*(\\begin\{(equation|align)\}.*?\\end\{\3\})[ \t]*\$\$[ \t]*$/gm;
+        return content.replace(
+            singleLinePattern,
+            (_match, indent, body, env) => {
+                let normalizedBody = body;
+                if (env === "align") {
+                    // The align scanner (processAlignEnvironment) is
+                    // line-based: it skips \begin/\end delimiter lines and
+                    // numbers one row per line, so put the delimiters on
+                    // their own lines and break rows at `\\`.
+                    normalizedBody = body
+                        .replace(/\\begin\{align\}[ \t]*/, "\\begin{align}\n")
+                        .replace(/[ \t]*\\end\{align\}$/, "\n\\end{align}")
+                        .replace(/\\\\[ \t]*/g, "\\\\\n");
+                }
+                return `${indent}$$\n${normalizedBody}\n$$`;
+            },
         );
     }
 
@@ -147,9 +196,11 @@ export class MarkdownProcessor {
     }
 
     private processEquations(content: string, sectionIndex: number): string {
-        // Matches both multi-line ($$\n\begin{...}...) and single-line
-        // ($$\begin{...}...\end{...}$$) display environments, with optional
-        // whitespace between the delimiters and the environment.
+        // Matches display environments with optional whitespace between the
+        // `$$` delimiters and the environment. Single-line forms have
+        // already been normalized to multi-line by
+        // normalizeSingleLineDisplayEnvironments(), so each equation is
+        // seen exactly once here.
         const equationPattern =
             /\$\$\s*\\begin\{(equation|align)\}[\s\S]*?\\end\{\1\}\s*\$\$/g;
         const equations = content.match(equationPattern);


### PR DESCRIPTION
## Problem

Follow-up to #66, fixing **ISSUE-1 / NEW-FINDING-1** from the vr-66 visual review: https://github.com/branyang02/notie/pull/66#issuecomment-5017193644

remark-math v6 parses a one-line `$$\begin{equation}...\end{equation}$$` as **inline** math, so KaTeX rejects the display-only `equation`/`align` environment with a red `.katex-error` ("`{equation} can be used only in display mode`") and never emits an `.eqn-num` span — so no `eqn-X.Y` anchor is ever created. Meanwhile, #66's relaxed equation regex correctly maps the `\label`, so the prose `$\eqref{...}$` renders as a clickable numbered link whose href points at an anchor that does not exist. The reference side and the render side disagree.

## Solution

`MarkdownProcessor.process()` gains a normalization step, `normalizeSingleLineDisplayEnvironments()`, that runs on the **masked** text (after `maskProtectedRegions`, before section splitting and equation scanning). It rewrites any single-line

```
$$\begin{equation}\label{eq:x} y = 1 \end{equation}$$
```

into the canonical multi-line form

```
$$
\begin{equation}\label{eq:x} y = 1 \end{equation}
$$
```

so remark-math parses it as display math, KaTeX renders it in a `.katex-display` block with an equation number, and the DOM-labeling effect creates the matching `#eqn-X.Y` anchor. Details:

- Runs on masked text, so single-line forms inside code blocks / HTML comments are untouched (restored verbatim).
- Runs before `processEquations`, so the scanner sees each equation exactly once via the normal multi-line path — no double counting. The regex comment is updated accordingly.
- Single-line `align` environments are also normalized, with rows additionally split at `\\` so the line-based align scanner (`processAlignEnvironment`) numbers each row exactly once, matching KaTeX's per-row numbering.
- Multi-line forms are not matched (the pattern requires the full `$$...$$` pair on one line), so previously-working documents are byte-identical.
- `markdownContent` / `markdownSections` returned to the renderer contain the normalized text — an intentional rendered-output change for this input, which is the point of the fix.

## Tests

New coverage (all existing tests pass unmodified):

- `MarkdownProcessor.test.ts`:
  - single-line equation with `\label` → label mapped as `1.1` **and** `markdownContent` contains the multi-line normalized form (and not the single-line form); `markdownContent === markdownSections.join("")`
  - single-line `align` with two labeled rows → rows numbered `1.1`/`1.2`, delimiters and rows on their own lines
  - single-line form inside a fenced code block → not mapped, restored verbatim (still single-line)
  - pre-existing single-line mapping tests (`eq:a`, document-order counting) pass unchanged
- `Notie.test.tsx`: rendering the single-line equation plus `$\eqref{eq:x}$` produces a `.katex-display` block, **no** `.katex-error`, an `(1.1)` eqref link, and a real `#eqn-1.1` anchor in the DOM matching the link's href.

`npm test` ✔ (163/163 across 23 files) `npm run lint` ✔ `npm run build` ✔ `npx prettier --check .` ✔ — no lockfile changes.

## Risk

Low. The rewrite only fires when a complete `$$\begin{equation|align}...\end{...}$$` pair sits on a single line — a form that previously rendered as a red ParseError, so any behavior change for it is strictly an improvement. Multi-line display math, inline math, and code/comment content (masked) are untouched. The align row-splitting mirrors exactly what the scanner and KaTeX already do for hand-written multi-line align blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)