### PR TITLE
fix: resolve list-indented equation refs

### DIFF
--- a/src/utils/MarkdownProcessor.test.ts
+++ b/src/utils/MarkdownProcessor.test.ts
@@ -264,6 +264,88 @@ $$
         );
     });
 
+    it("maps labels inside list-continuation display equations", () => {
+        const markdown = [
+            "# Title",
+            "",
+            "## Section",
+            "",
+            "1. **Case One**: A displayed equation belongs to this list item:",
+            "",
+            "    $$",
+            "    \\begin{equation} \\label{eq:list-equation}",
+            "    x = 1",
+            "    \\end{equation}",
+            "    $$",
+            "",
+            "    See $\\eqref{eq:list-equation}$ from inside the same item.",
+            "",
+            "See it again from outside: $\\eqref{eq:list-equation}$.",
+            "",
+        ].join("\n");
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.equationMapping["eq:list-equation"]).toBeDefined();
+        expect(result.equationMapping["eq:list-equation"].equationNumber).toBe(
+            "1.1",
+        );
+        expect(
+            result.equationMapping["eq:list-equation"].equationString,
+        ).toContain("x = 1");
+    });
+
+    it("maps list-continuation equations after lazy continuation text", () => {
+        const markdown = [
+            "# Title",
+            "",
+            "## Section",
+            "",
+            "3. **Case Three**: A list item begins here,",
+            "and this unindented line lazily continues the same item:",
+            "",
+            "    $$",
+            "    \\begin{align}",
+            "    y &= 1 \\label{eq:lazy-list-align} \\\\",
+            "    \\end{align}",
+            "    $$",
+            "",
+            "The reference $\\eqref{eq:lazy-list-align}$ should resolve.",
+            "",
+        ].join("\n");
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.equationMapping["eq:lazy-list-align"]).toBeDefined();
+        expect(
+            result.equationMapping["eq:lazy-list-align"].equationNumber,
+        ).toBe("1.1");
+    });
+
+    it("still ignores labels inside code blocks nested in list items", () => {
+        const markdown = [
+            "# Title",
+            "",
+            "## Section",
+            "",
+            "1. Item with an indented code block:",
+            "",
+            "       $$",
+            "       \\begin{equation} \\label{eq:list-code}",
+            "       x = 1",
+            "       \\end{equation}",
+            "       $$",
+            "",
+        ].join("\n");
+
+        const result = new MarkdownProcessor(markdown, config).process();
+
+        expect(result.equationMapping).toEqual({});
+        expect(result.markdownContent).toContain(
+            "       \\begin{equation} \\label{eq:list-code}",
+        );
+    });
+
     it("does not let a stray ``` in prose swallow later content", () => {
         const markdown = `# Title
 

--- a/src/utils/MarkdownProcessor.ts
+++ b/src/utils/MarkdownProcessor.ts
@@ -192,7 +192,7 @@ export class MarkdownProcessor {
      */
     private warnTitleSectionLabels(content: string): void {
         const equationPattern =
-            /\$\$\s*\\begin\{(equation|align|gather|alignat)\}(?:\{\d+\})?[\s\S]*?\\end\{\1\}\s*\$\$/g;
+            /^[ \t]*\$\$\s*\\begin\{(equation|align|gather|alignat)\}(?:\{\d+\})?[\s\S]*?\\end\{\1\}\s*\$\$/gm;
         let match;
         while ((match = equationPattern.exec(content)) !== null) {
             const labelPattern = /\\label\{(.*?)\}/g;
@@ -281,7 +281,7 @@ export class MarkdownProcessor {
         // optional `\{\d+\}` allows it while the \1 back-reference still
         // pairs \begin{env} with the matching \end{env}.
         const equationPattern =
-            /\$\$\s*\\begin\{(equation|align|gather|alignat)\}(?:\{\d+\})?[\s\S]*?\\end\{\1\}\s*\$\$/g;
+            /^[ \t]*\$\$\s*\\begin\{(equation|align|gather|alignat)\}(?:\{\d+\})?[\s\S]*?\\end\{\1\}\s*\$\$/gm;
         let currEquationNumber = 1;
 
         let match;

--- a/src/utils/markdownMasking.ts
+++ b/src/utils/markdownMasking.ts
@@ -24,6 +24,90 @@ const isBlank = (line: string): boolean => line.trim() === "";
 const isIndentedCodeLine = (line: string): boolean =>
     /^(?: {4}|\t)/.test(line) && !isBlank(line);
 
+const indentationColumns = (line: string): number => {
+    let columns = 0;
+    for (const char of line) {
+        if (char === " ") {
+            columns++;
+            continue;
+        }
+        if (char === "\t") {
+            columns += 4;
+            continue;
+        }
+        break;
+    }
+    return columns;
+};
+
+const prefixColumns = (text: string): number => {
+    let columns = 0;
+    for (const char of text) {
+        columns += char === "\t" ? 4 : 1;
+    }
+    return columns;
+};
+
+const listMarkerMatch = (
+    line: string,
+): { markerIndent: number; contentIndent: number } | null => {
+    const match = line.match(/^([ \t]*)(?:[-+*]|\d+[.)])([ \t]+)/);
+    if (!match) return null;
+    return {
+        markerIndent: indentationColumns(match[1]),
+        contentIndent: prefixColumns(match[0]),
+    };
+};
+
+const listContinuationContext = (
+    lines: string[],
+    index: number,
+): { contentIndent: number } | null => {
+    const currentIndent = indentationColumns(lines[index]);
+
+    const findLazyContinuationMarker = (
+        startIndex: number,
+    ): { contentIndent: number } | null => {
+        for (let i = startIndex; i >= 0; i--) {
+            const line = lines[i];
+            if (isBlank(line)) return null;
+
+            const marker = listMarkerMatch(line);
+            if (marker && marker.markerIndent < currentIndent) {
+                return { contentIndent: marker.contentIndent };
+            }
+        }
+
+        return null;
+    };
+
+    for (let i = index - 1; i >= 0; i--) {
+        const line = lines[i];
+        if (isBlank(line)) continue;
+
+        const marker = listMarkerMatch(line);
+        if (marker && marker.markerIndent < currentIndent) {
+            return { contentIndent: marker.contentIndent };
+        }
+
+        if (indentationColumns(line) < currentIndent) {
+            return findLazyContinuationMarker(i - 1);
+        }
+    }
+
+    return null;
+};
+
+const isIndentedCodeBlockStart = (lines: string[], index: number): boolean => {
+    const line = lines[index];
+    if (!isIndentedCodeLine(line)) return false;
+
+    const listContext = listContinuationContext(lines, index);
+    if (!listContext) return true;
+
+    return indentationColumns(line) >= listContext.contentIndent + 4;
+};
+
 export function maskProtectedRegions(text: string): MaskResult {
     // Grow the token base until it cannot collide with document content.
     let base = "NOTIEMASK";
@@ -81,11 +165,11 @@ export function maskProtectedRegions(text: string): MaskResult {
         // (or at the start of the document). Interior blank lines are part
         // of the block only when followed by another indented line.
         const prevBlank = out.length === 0 || isBlank(out[out.length - 1]);
-        if (isIndentedCodeLine(line) && prevBlank) {
+        if (isIndentedCodeBlockStart(lines, i) && prevBlank) {
             const block: string[] = [line];
             i++;
             while (i < lines.length) {
-                if (isIndentedCodeLine(lines[i])) {
+                if (isIndentedCodeBlockStart(lines, i)) {
                     block.push(lines[i]);
                     i++;
                     continue;
@@ -95,7 +179,10 @@ export function maskProtectedRegions(text: string): MaskResult {
                     while (j < lines.length && isBlank(lines[j])) {
                         j++;
                     }
-                    if (j < lines.length && isIndentedCodeLine(lines[j])) {
+                    if (
+                        j < lines.length &&
+                        isIndentedCodeBlockStart(lines, j)
+                    ) {
                         while (i < j) {
                             block.push(lines[i]);
                             i++;


### PR DESCRIPTION
## Summary
- keep list-continuation display math visible to equation/blockquote scanning while still masking real indented code blocks
- allow indented display-math delimiters when building equation mappings
- add regressions for list-indented equations, lazy list continuation text, and nested list code blocks

## Root Cause
The document-level masker treated four-space-indented display math inside Markdown list items as protected code. The renderer still displayed those equations, but the equation mapping skipped their labels, so real `brandonyang` notes rendered visible unresolved `\eqref` errors.

## Validation
- `npm test -- --run src/utils/MarkdownProcessor.test.ts`
- Broader E2E verification already performed against a temporary `brandonyang` clone linked to the fixed packed Notie build.